### PR TITLE
Add keyboard navigation to mobile menu

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -39,7 +39,7 @@ export const Header = (): React.ReactElement => {
     return () => document.removeEventListener('keydown', handleEscape);
   }, [mobileMenuOpen]);
 
-  // Focus trap for mobile menu
+  // Focus trap and arrow key navigation for mobile menu
   useEffect(() => {
     if (!mobileMenuOpen || !menuRef.current) return;
 
@@ -50,30 +50,72 @@ export const Header = (): React.ReactElement => {
     const firstFocusable = focusableElements[0];
     const lastFocusable = focusableElements[focusableElements.length - 1];
 
-    const handleTabKey = (event: KeyboardEvent) => {
-      if (event.key !== 'Tab') return;
+    const handleKeyboardNavigation = (event: KeyboardEvent) => {
+      const { key, shiftKey } = event;
 
-      if (event.shiftKey) {
-        // Shift + Tab
-        if (document.activeElement === firstFocusable) {
-          event.preventDefault();
-          lastFocusable?.focus();
+      // Handle Tab key for focus trap
+      if (key === 'Tab') {
+        if (shiftKey) {
+          // Shift + Tab
+          if (document.activeElement === firstFocusable) {
+            event.preventDefault();
+            lastFocusable?.focus();
+          }
+        } else {
+          // Tab
+          if (document.activeElement === lastFocusable) {
+            event.preventDefault();
+            firstFocusable?.focus();
+          }
         }
-      } else {
-        // Tab
-        if (document.activeElement === lastFocusable) {
-          event.preventDefault();
-          firstFocusable?.focus();
+        return;
+      }
+
+      // Handle arrow keys, Home, and End for menu navigation
+      if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(key)) {
+        event.preventDefault();
+
+        const currentIndex = Array.from(focusableElements).indexOf(
+          document.activeElement as HTMLElement
+        );
+
+        let targetIndex: number;
+
+        switch (key) {
+          case 'ArrowDown':
+            // Move to next item, wrap to first if at end
+            targetIndex = currentIndex < focusableElements.length - 1
+              ? currentIndex + 1
+              : 0;
+            break;
+          case 'ArrowUp':
+            // Move to previous item, wrap to last if at beginning
+            targetIndex = currentIndex > 0
+              ? currentIndex - 1
+              : focusableElements.length - 1;
+            break;
+          case 'Home':
+            // Jump to first item
+            targetIndex = 0;
+            break;
+          case 'End':
+            // Jump to last item
+            targetIndex = focusableElements.length - 1;
+            break;
+          default:
+            return;
         }
+
+        focusableElements[targetIndex]?.focus();
       }
     };
 
-    menu.addEventListener('keydown', handleTabKey);
+    menu.addEventListener('keydown', handleKeyboardNavigation);
 
     // Focus first element when menu opens
     firstFocusable?.focus();
 
-    return () => menu.removeEventListener('keydown', handleTabKey);
+    return () => menu.removeEventListener('keydown', handleKeyboardNavigation);
   }, [mobileMenuOpen]);
 
   return (


### PR DESCRIPTION
Implemented arrow key navigation (Up/Down, Home/End) for the mobile menu to improve accessibility and keyboard-only user experience. This completes the Phase 1 Week 1 critical accessibility requirement.

Changes:
- Added ArrowDown/ArrowUp keys to navigate between menu items with wrapping
- Added Home/End keys to jump to first/last menu items
- Enhanced existing Tab key focus trap implementation
- Maintained focus management (returns focus to menu button on close)
- All navigation properly prevents default scrolling behavior

The mobile menu now supports full keyboard navigation:
- Tab/Shift+Tab: Move through items (with focus trap)
- ArrowDown/ArrowUp: Navigate menu items (with wrapping)
- Home/End: Jump to first/last item
- Escape: Close menu and return focus to button
- Enter/Space: Activate focused item (native button behavior)

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->


### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
