### PR TITLE
Fix missing Lighthouse CI artifacts warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           name: lighthouse-results
           path: .lighthouseci/
           retention-days: 30
+          if-no-files-found: ignore
 
   # Status check job that all required jobs depend on
   ci-success:

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -3,6 +3,7 @@
     "collect": {
       "staticDistDir": "./dist",
       "numberOfRuns": 3,
+      "outputDir": "./.lighthouseci",
       "settings": {
         "preset": "desktop",
         "throttling": {


### PR DESCRIPTION
### Summary and Changes

- Add if-no-files-found: ignore to upload-artifact action to prevent warnings when .lighthouseci/ is empty
- Configure explicit outputDir in .lighthouserc.json to ensure Lighthouse CI creates the directory consistently

This resolves the "No files were found with the provided path" warning in GitHub Actions.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: n/a

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
