### PR TITLE
Fix failing tests

### DIFF
--- a/src/components/ui/Icon/Icon.tsx
+++ b/src/components/ui/Icon/Icon.tsx
@@ -15,7 +15,7 @@ export const Icon: React.FC<IconProps> = ({
 }) => {
   const sizeClass = {
       sm: 'fa-sm',
-      md: 'fa-lg', // or '' if you want md as default (no class)
+      md: '', // Medium size is default (no class)
       lg: 'fa-lg',
       xl: 'fa-xl',
       '2x': 'fa-2x',


### PR DESCRIPTION
### Summary

The medium ('md') size should not add any Font Awesome size class, as it represents the default/baseline icon size. Changed from 'fa-lg' to empty string to match expected test behavior.

This fixes the failing Icon test that expected no size class for the default medium size.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
