### PR TITLE
security: Add explicit permissions block to ci-success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint-and-typecheck, build, lighthouse]
     if: always()
+    permissions: {}
 
     steps:
       - name: Check all jobs status


### PR DESCRIPTION
### Summary

Fix CodeQL security alert by adding an explicit permissions block to the ci-success job in the CI workflow. This follows security best practices by limiting GITHUB_TOKEN permissions to the minimum required.

Since the ci-success job only checks the status of other jobs and doesn't interact with the repository, it requires no permissions.

Fixes: https://github.com/shazzar00ni/paperlyte-v2/security/code-scanning/4


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
