### PR TITLE
Set up Lighthouse CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint-and-typecheck, build, lighthouse]
     if: always()
-    permissions: {}
+    permissions:
+      contents: read
 
     steps:
       - name: Check all jobs status


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Update the ci-success job to use 'contents: read' permission instead of an empty permissions block. This follows the principle of least privilege and resolves the CodeQL security alert about missing workflow permissions.


### Changes
<!-- Describe the changes this pull request introduces. -->

Fixes: CodeQL alert actions/missing-workflow-permissions

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
