### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/shazzar00ni/paperlyte-v2/security/code-scanning/2](https://github.com/shazzar00ni/paperlyte-v2/security/code-scanning/2)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since none of the jobs write to the repository, issues, or pull requests, the minimal and appropriate scope is `contents: read`. The cleanest way without altering behavior is to set this at the workflow root so it applies to all jobs that don’t override it.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add a top-level `permissions:` block right after the `name:` (or before `on:`) with `contents: read`.
- This ensures all jobs (`lint-and-typecheck`, `build`, `size-check`, `lighthouse`, `ci-success`, etc.) run with a read-only token unless they define their own permissions.
- No additional imports, actions, or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
