### PR TITLE
Fix FAQ timer test fake timers compatibility

### DIFF
--- a/src/components/sections/FAQ/FAQ.test.tsx
+++ b/src/components/sections/FAQ/FAQ.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FAQ } from './FAQ'
 import { FAQ_ITEMS } from '@constants/faq'
@@ -489,21 +489,24 @@ describe('FAQ', () => {
       expect(liveRegion).toHaveAttribute('aria-atomic', 'true')
     })
 
-    it('should clear announcement after toggling', async () => {
+    it('should clear announcement after toggling', () => {
       vi.useFakeTimers()
-      const user = userEvent.setup()
       render(<FAQ />)
 
       const item = FAQ_ITEMS[0]
       const questionButton = screen.getByRole('button', { name: new RegExp(item.question, 'i') })
 
-      await user.click(questionButton)
+      // Use fireEvent instead of userEvent to avoid conflicts with fake timers
+      fireEvent.click(questionButton)
 
       const liveRegion = document.querySelector('[aria-live="polite"]')
       expect(liveRegion).toHaveTextContent(`${item.question} expanded`)
 
       // Advance timers by 3100ms to trigger the announcement clear timeout
-      vi.advanceTimersByTime(3100)
+      // Wrap in act() to ensure React state updates are flushed
+      act(() => {
+        vi.advanceTimersByTime(3100)
+      })
 
       expect(liveRegion).toHaveTextContent('')
 


### PR DESCRIPTION
### Summary/Changes

- Replace userEvent with fireEvent to avoid timing conflicts with vi.useFakeTimers()
- Wrap vi.advanceTimersByTime() in act() to ensure React state updates are flushed
- Import fireEvent and act from @testing-library/react
- Remove async/await since fireEvent is synchronous

This resolves the test timeout issue when testing the announcement clear timeout functionality.

<!-- A clear and concise description of what the problem or opportunity is. -->

<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->


### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
