### PR TITLE
Update CI to use codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,20 +71,22 @@ jobs:
         run: npm run test:coverage -- --run
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: always()
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: ./junit.xml
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
### Changes

- Upgrade codecov/codecov-action from v4 to v5
- Replace deprecated codecov/test-results-action@v1 with codecov-action@v5
- Add report_type: test_results for JUnit XML test results upload
- Reference junit.xml file generated by vitest configuration

This resolves the deprecation warnings and upload failures in CI.

<!-- A clear and concise description of what the problem or opportunity is. -->


<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
