### PR TITLE
Fix invalid Codecov YAML configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
   # Round coverage values
   round: down
   # Range for coverage display (red to green)
-  range: "70...100"
+  range: "70..100"
 
   # Overall project status
   status:


### PR DESCRIPTION
### Changes

- Change range from '70...100' to '70..100' (three dots to two dots)
- Codecov YAML validator requires two-dot range syntax
- This should resolve the 'yaml appears to be invalid' error

<!-- A clear and concise description of what the problem or opportunity is. -->


<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
