### PR TITLE
Remove development console.log statements

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -74,9 +74,6 @@ class Analytics {
 
     this.initialized = true
 
-    if (config.debug) {
-      console.log('[Analytics] Initialized with config:', config)
-    }
   }
 
   /**
@@ -124,12 +121,6 @@ class Analytics {
 
     this.provider?.trackPageView(url)
 
-    if (this.config?.debug) {
-      console.log(
-        '[Analytics] Page view tracked:',
-        url || (typeof window !== 'undefined' ? window.location.pathname : '/')
-      )
-    }
   }
 
   /**
@@ -150,9 +141,6 @@ class Analytics {
 
     this.provider?.trackEvent(eventWithTimestamp)
 
-    if (this.config?.debug) {
-      console.log('[Analytics] Event tracked:', eventWithTimestamp)
-    }
   }
 
   /**
@@ -167,9 +155,6 @@ class Analytics {
 
     this.provider?.trackWebVitals(vitals)
 
-    if (this.config?.debug) {
-      console.log('[Analytics] Web Vitals tracked:', vitals)
-    }
   }
 
   /**
@@ -235,8 +220,6 @@ class Analytics {
       return
     }
 
-    const debug = this.config?.debug
-
     // Disable provider
     this.provider?.disable()
 
@@ -257,9 +240,6 @@ class Analytics {
     this.config = null
     this.provider = null
 
-    if (debug) {
-      console.log('[Analytics] Disabled')
-    }
   }
 
   /**
@@ -267,8 +247,6 @@ class Analytics {
    * Unconditionally clears all internal state - useful for testing
    */
   reset(): void {
-    const debug = this.config?.debug
-
     // Disable provider regardless of state
     if (this.provider) {
       this.provider.disable()
@@ -291,9 +269,6 @@ class Analytics {
     this.initialized = false
     this.config = null
 
-    if (debug) {
-      console.log('[Analytics] Reset')
-    }
   }
 
   /**

--- a/src/analytics/providers/plausible.ts
+++ b/src/analytics/providers/plausible.ts
@@ -26,17 +26,11 @@ export class PlausibleProvider implements AnalyticsProvider {
    */
   init(config: AnalyticsConfig): void {
     if (this.initialized) {
-      if (config.debug) {
-        console.log('[Analytics] Plausible already initialized')
-      }
       return
     }
 
     // Check if user has Do Not Track enabled
     if (config.respectDNT !== false && this.isDNTEnabled()) {
-      if (config.debug) {
-        console.log('[Analytics] Do Not Track is enabled, analytics disabled')
-      }
       return
     }
 
@@ -46,9 +40,6 @@ export class PlausibleProvider implements AnalyticsProvider {
     // Load Plausible script asynchronously
     this.loadScript()
 
-    if (config.debug) {
-      console.log('[Analytics] Plausible initialized', config)
-    }
   }
 
   /**
@@ -147,9 +138,6 @@ export class PlausibleProvider implements AnalyticsProvider {
 
     script.onload = () => {
       this.scriptLoaded = true
-      if (this.config?.debug) {
-        console.log('[Analytics] Plausible script loaded successfully')
-      }
     }
 
     // Store reference to the script element for cleanup
@@ -173,9 +161,6 @@ export class PlausibleProvider implements AnalyticsProvider {
       props: { path: pageUrl },
     })
 
-    if (this.config?.debug) {
-      console.log('[Analytics] Page view tracked:', pageUrl)
-    }
   }
 
   /**
@@ -211,9 +196,6 @@ export class PlausibleProvider implements AnalyticsProvider {
 
     window.plausible(event.name, props ? { props } : undefined)
 
-    if (this.config?.debug) {
-      console.log('[Analytics] Event tracked:', event.name, props)
-    }
   }
 
   /**
@@ -242,9 +224,6 @@ export class PlausibleProvider implements AnalyticsProvider {
       }
     })
 
-    if (this.config?.debug) {
-      console.log('[Analytics] Core Web Vitals tracked:', vitals)
-    }
   }
 
   /**
@@ -264,8 +243,6 @@ export class PlausibleProvider implements AnalyticsProvider {
    * Removes the Plausible script and resets state
    */
   disable(): void {
-    const debug = this.config?.debug
-
     this.initialized = false
     this.scriptLoaded = false
     this.config = null
@@ -284,9 +261,6 @@ export class PlausibleProvider implements AnalyticsProvider {
       delete window.plausible
     }
 
-    if (debug) {
-      console.log('[Analytics] Plausible disabled')
-    }
   }
 
   /**

--- a/src/components/ui/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/components/ui/FeedbackWidget/FeedbackWidget.tsx
@@ -131,7 +131,6 @@ export const FeedbackWidget = ({ onSubmit }: FeedbackWidgetProps): React.ReactEl
               }`
             )
           }
-          console.log('Feedback submitted:', feedbackEntry)
         }
 
         // Show confirmation

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -290,11 +290,6 @@ export function trackEvent(eventName: string, eventParams?: AnalyticsEventParams
   const sanitizedParams = sanitizeAnalyticsParams(eventParams)
 
   if (!isAnalyticsAvailable()) {
-    // In development, log to console instead of failing silently
-    // Only log sanitized params (never log PII)
-    if (import.meta.env.DEV) {
-      console.log('[Analytics]', eventName, sanitizedParams)
-    }
     return
   }
 
@@ -318,9 +313,6 @@ export function trackEvent(eventName: string, eventParams?: AnalyticsEventParams
  */
 export function trackPageView(pagePath: string, pageTitle?: string): void {
   if (!isAnalyticsAvailable()) {
-    if (import.meta.env.DEV) {
-      console.log('[Analytics] Page View:', pagePath, pageTitle)
-    }
     return
   }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -87,12 +87,4 @@ export const updateMetaTags = (): void => {
     ogImage.setAttribute('content', env.ogImage)
   }
 
-  // Log environment info in development
-  if (env.isDevelopment) {
-    console.log('🌍 Environment:', {
-      baseUrl: env.baseUrl,
-      ogImage: env.ogImage,
-      mode: import.meta.env.MODE,
-    })
-  }
 }

--- a/src/utils/metaTags.ts
+++ b/src/utils/metaTags.ts
@@ -53,12 +53,5 @@ export function initializeMetaTags(): void {
       twitterImage.setAttribute('content', currentUrl + '/og-image.png')
     }
 
-    // Log for debugging
-    console.log('[Meta Tags] Initialized for development environment')
-    console.log('  - Robots: noindex, nofollow')
-    console.log('  - Keywords: removed')
-    console.log('  - Canonical URL: unchanged (points to production)')
-    console.log(`  - Open Graph URLs: updated to ${currentUrl}`)
-    console.log(`  - Twitter Card URLs: updated to ${currentUrl}`)
   }
 }

--- a/src/utils/monitoring.ts
+++ b/src/utils/monitoring.ts
@@ -51,15 +51,6 @@ export function logError(error: Error, context?: ErrorContext, source?: string):
   if (import.meta.env.DEV) {
     console.group(`[${severity.toUpperCase()}] Error from ${errorSource}`)
     console.error(error)
-    if (context?.componentStack) {
-      console.log('Component Stack:', context.componentStack)
-    }
-    if (context?.errorInfo) {
-      console.log('Additional Info:', context.errorInfo)
-    }
-    if (context?.tags) {
-      console.log('Tags:', context.tags)
-    }
     console.groupEnd()
     return
   }
@@ -148,7 +139,6 @@ export function logPerformance(
   unit: 'ms' | 'bytes' | 'count' = 'ms'
 ): void {
   if (import.meta.env.DEV) {
-    console.log(`[Performance] ${metric}: ${value}${unit}`)
     return
   }
 
@@ -169,9 +159,5 @@ export function logEvent(
   eventName: string,
   properties?: Record<string, string | number | boolean>
 ): void {
-  if (import.meta.env.DEV) {
-    console.log('[Event]', eventName, properties)
-  }
-
   trackEvent(eventName, properties)
 }


### PR DESCRIPTION
Removes all console.log calls used for development/debug logging across
analytics, monitoring, meta tags, environment, and feedback widget files.
Retains console.error and console.warn for legitimate error reporting.
Also cleans up orphaned debug variable declarations left after log removal.

https://claude.ai/code/session_01XmJRTByCoWDhy3TTUWgv8q