### PR TITLE
fix: add CodeQL advanced setup to resolve Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,11 @@
 # CodeQL Advanced Setup
-# Provides an advanced CodeQL configuration that allows setting the Node.js runtime version.
-# If GitHub's default CodeQL "default setup" is enabled for this repository, disable it manually in
-# the Code scanning settings to avoid running CodeQL twice (duplicate alerts/checks).
-# See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+# Provides an advanced CodeQL configuration that:
+#   - Pins all actions to specific SHAs (actions/checkout v6.0.2, codeql-action v4.34.1)
+#   - Opts into Node.js 24 via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to silence Node.js 20
+#     deprecation warnings on the runner (see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
+#   - Skips SARIF upload for forked PRs that lack security-events:write permission
+# NOTE: If GitHub's default CodeQL "default setup" is enabled for this repository, disable it
+# manually in Code scanning settings to avoid running CodeQL twice (duplicate alerts/checks).
 
 name: "CodeQL"
 
@@ -48,5 +51,8 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        # Forked PRs run with reduced permissions and cannot write to the Security tab;
+        # swallow the error there but let it fail loudly on main pushes and scheduled runs.
+        continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+# CodeQL Advanced Setup
+# Replaces GitHub's default CodeQL setup to allow configuration of the Node.js runtime version.
+# See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "30 1 * * 0"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,7 @@
 # CodeQL Advanced Setup
-# Replaces GitHub's default CodeQL setup to allow configuration of the Node.js runtime version.
+# Provides an advanced CodeQL configuration that allows setting the Node.js runtime version.
+# If GitHub's default CodeQL "default setup" is enabled for this repository, disable it manually in
+# the Code scanning settings to avoid running CodeQL twice (duplicate alerts/checks).
 # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 
 name: "CodeQL"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron: "30 1 * * 0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Creates an explicit codeql.yml workflow to replace GitHub's default CodeQL
setup, setting FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to opt into Node.js 24 and silence the deprecation warnings for actions/checkout@v4.