### PR TITLE
fix: upgrade axios to 1.15.0 to resolve SSRF vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4109,15 +4109,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4262,9 +4262,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7121,9 +7121,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     }
   ],
   "overrides": {
+    "axios": "^1.15.0",
     "brace-expansion": "^5.0.5",
     "path-to-regexp": "^0.1.13",
     "tmp": "^0.2.5",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
   ],
   "overrides": {
     "axios": "^1.15.0",
+    "basic-ftp": "^5.2.1",
+    "lodash-es": "^4.18.0",
     "brace-expansion": "^5.0.5",
     "path-to-regexp": "^0.1.13",
     "tmp": "^0.2.5",

--- a/src/test/workflow-validation.test.ts
+++ b/src/test/workflow-validation.test.ts
@@ -289,3 +289,139 @@ describe('package-lock.json – picomatch dependency update', () => {
     expect(lockfile.lockfileVersion).toBeGreaterThanOrEqual(1)
   })
 })
+
+// ---------------------------------------------------------------------------
+// package-lock.json – axios SSRF fix (GHSA-3p68-rc4w-qgx5)
+// Axios < 1.15.0 has a NO_PROXY hostname normalisation bypass that can lead
+// to SSRF. The override in package.json forces >= 1.15.0.
+// ---------------------------------------------------------------------------
+
+describe('package-lock.json – axios security update (GHSA-3p68-rc4w-qgx5)', () => {
+  interface PackageLock {
+    lockfileVersion: number
+    packages: Record<string, { version: string; resolved: string; dev?: boolean }>
+  }
+
+  let lockfile: PackageLock
+  let entry: { version: string; resolved: string; dev?: boolean }
+
+  beforeAll(() => {
+    const raw = readFileSync(resolve(projectRoot, 'package-lock.json'), 'utf-8')
+    lockfile = JSON.parse(raw) as PackageLock
+    entry = lockfile.packages['node_modules/axios']
+  })
+
+  it('should have axios listed in packages', () => {
+    expect(lockfile.packages).toHaveProperty('node_modules/axios')
+  })
+
+  it('axios version should be >= 1.15.0 (not vulnerable)', () => {
+    const [major, minor, patch] = entry.version.split('.').map(Number)
+    const isAtLeast1_15_0 =
+      major > 1 || (major === 1 && minor > 15) || (major === 1 && minor === 15 && patch >= 0)
+    expect(isAtLeast1_15_0, `axios ${entry.version} is below the minimum safe version 1.15.0`).toBe(
+      true
+    )
+  })
+
+  it('axios should NOT be the vulnerable version range (< 1.15.0)', () => {
+    const [major, minor] = entry.version.split('.').map(Number)
+    expect(major === 1 && minor < 15).toBe(false)
+  })
+
+  it('axios resolved URL should point to a non-vulnerable release', () => {
+    expect(entry.resolved).toContain('axios-1.15.')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// package-lock.json – basic-ftp FTP command injection fix (GHSA-chqc-8p9q-pq6q)
+// basic-ftp 5.2.0 allows FTP command injection via CRLF sequences.
+// The override in package.json forces >= 5.2.1.
+// ---------------------------------------------------------------------------
+
+describe('package-lock.json – basic-ftp security update (GHSA-chqc-8p9q-pq6q)', () => {
+  interface PackageLock {
+    lockfileVersion: number
+    packages: Record<string, { version: string; resolved: string; dev?: boolean }>
+  }
+
+  let lockfile: PackageLock
+  let entry: { version: string; resolved: string; dev?: boolean }
+
+  beforeAll(() => {
+    const raw = readFileSync(resolve(projectRoot, 'package-lock.json'), 'utf-8')
+    lockfile = JSON.parse(raw) as PackageLock
+    entry = lockfile.packages['node_modules/basic-ftp']
+  })
+
+  it('should have basic-ftp listed in packages', () => {
+    expect(lockfile.packages).toHaveProperty('node_modules/basic-ftp')
+  })
+
+  it('basic-ftp should NOT be the vulnerable version 5.2.0', () => {
+    expect(entry.version).not.toBe('5.2.0')
+  })
+
+  it('basic-ftp version should be >= 5.2.1 (not vulnerable)', () => {
+    const [major, minor, patch] = entry.version.split('.').map(Number)
+    const isAtLeast5_2_1 =
+      major > 5 || (major === 5 && minor > 2) || (major === 5 && minor === 2 && patch >= 1)
+    expect(
+      isAtLeast5_2_1,
+      `basic-ftp ${entry.version} is below the minimum safe version 5.2.1`
+    ).toBe(true)
+  })
+
+  it('basic-ftp resolved URL should not point to the vulnerable 5.2.0 release', () => {
+    expect(entry.resolved).not.toContain('basic-ftp-5.2.0.tgz')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// package-lock.json – lodash-es prototype pollution / code injection fix
+// (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh)
+// lodash-es <= 4.17.23 is affected. The override in package.json forces >= 4.18.0.
+// ---------------------------------------------------------------------------
+
+describe('package-lock.json – lodash-es security update (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh)', () => {
+  interface PackageLock {
+    lockfileVersion: number
+    packages: Record<string, { version: string; resolved: string; dev?: boolean }>
+  }
+
+  let lockfile: PackageLock
+  let entry: { version: string; resolved: string; dev?: boolean }
+
+  beforeAll(() => {
+    const raw = readFileSync(resolve(projectRoot, 'package-lock.json'), 'utf-8')
+    lockfile = JSON.parse(raw) as PackageLock
+    entry = lockfile.packages['node_modules/lodash-es']
+  })
+
+  it('should have lodash-es listed in packages', () => {
+    expect(lockfile.packages).toHaveProperty('node_modules/lodash-es')
+  })
+
+  it('lodash-es should NOT be at or below the vulnerable version 4.17.23', () => {
+    const [major, minor, patch] = entry.version.split('.').map(Number)
+    const isVulnerable =
+      major < 4 || (major === 4 && minor < 17) || (major === 4 && minor === 17 && patch <= 23)
+    expect(isVulnerable, `lodash-es ${entry.version} is in the vulnerable range (<= 4.17.23)`).toBe(
+      false
+    )
+  })
+
+  it('lodash-es version should be >= 4.18.0 (not vulnerable)', () => {
+    const [major, minor] = entry.version.split('.').map(Number)
+    const isAtLeast4_18 = major > 4 || (major === 4 && minor >= 18)
+    expect(
+      isAtLeast4_18,
+      `lodash-es ${entry.version} is below the minimum safe version 4.18.0`
+    ).toBe(true)
+  })
+
+  it('lodash-es resolved URL should not point to a vulnerable release', () => {
+    expect(entry.resolved).not.toMatch(/lodash-es-4\.17\.\d+\.tgz/)
+  })
+})

--- a/src/test/workflow-validation.test.ts
+++ b/src/test/workflow-validation.test.ts
@@ -102,13 +102,16 @@ describe('ci.yml – permission structure', () => {
       assertJobExists(content, jobId, 'ci.yml')
       // These jobs rely on the workflow-level contents: read (no separate job-level block needed)
       expect(hasWorkflowLevelPermissions(content)).toBe(true)
-    },
+    }
   )
 
-  it.each(['test', 'e2e', 'ci-success'])('%s job should have "contents: read" permission', (jobId) => {
-    const block = assertJobExists(content, jobId, 'ci.yml')
-    expect(jobHasContentsReadPermission(block)).toBe(true)
-  })
+  it.each(['test', 'e2e', 'ci-success'])(
+    '%s job should have "contents: read" permission',
+    (jobId) => {
+      const block = assertJobExists(content, jobId, 'ci.yml')
+      expect(jobHasContentsReadPermission(block)).toBe(true)
+    }
+  )
 
   it('should define the expected set of jobs', () => {
     const expectedJobs = [
@@ -134,7 +137,7 @@ describe('ci.yml – permission structure', () => {
       const block = assertJobExists(content, jobId, 'ci.yml')
       expect(
         jobHasContentsReadPermission(block),
-        `Job "${jobId}" is missing "contents: read" permission`,
+        `Job "${jobId}" is missing "contents: read" permission`
       ).toBe(true)
     }
   })
@@ -175,7 +178,7 @@ describe('pr-quality-check.yml – permission structure', () => {
       assertJobExists(content, jobId, 'pr-quality-check.yml')
       // These jobs rely on the workflow-level contents: read (no separate job-level block needed)
       expect(hasWorkflowLevelPermissions(content)).toBe(true)
-    },
+    }
   )
 
   it('dependency-review job should retain its existing permissions', () => {
@@ -185,7 +188,12 @@ describe('pr-quality-check.yml – permission structure', () => {
   })
 
   it('should define all expected jobs', () => {
-    const expectedJobs = ['pr-metadata', 'dependency-review', 'bundle-size-check', 'quality-summary']
+    const expectedJobs = [
+      'pr-metadata',
+      'dependency-review',
+      'bundle-size-check',
+      'quality-summary',
+    ]
     for (const jobId of expectedJobs) {
       assertJobExists(content, jobId, 'pr-quality-check.yml')
     }
@@ -213,7 +221,7 @@ describe('pr-quality-check.yml – permission structure', () => {
     const hasPermissionsBlock = /^\s{4}permissions:/m.test(block)
     expect(
       hasPermissionsBlock,
-      'dependency-review job is missing an explicit permissions block',
+      'dependency-review job is missing an explicit permissions block'
     ).toBe(true)
   })
 })
@@ -264,7 +272,7 @@ describe('package-lock.json – picomatch dependency update', () => {
 
   it('picomatch integrity hash should match the 4.0.4 release', () => {
     expect(entry.integrity).toBe(
-      'sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==',
+      'sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=='
     )
   })
 


### PR DESCRIPTION
Adds an npm override to force axios >= 1.15.0 across all transitive
dependencies (specifically wait-on which required ^1.13.5). Fixes the
critical GHSA-3p68-rc4w-qgx5 NO_PROXY hostname normalization bypass
that could lead to SSRF.

Also pins basic-ftp >= 5.2.1 (GHSA-chqc-8p9q-pq6q) and lodash-es >= 4.18.0 (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh), both transitively pulled in by @lhci/cli, surfaced by the same npm audit run.