### PR TITLE
ci: update dependency-review-action to v4.9.0 and Node.js 24

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pr-metadata:
     name: PR Metadata Check
@@ -62,8 +65,6 @@ jobs:
       contents: read
       pull-requests: write
     if: github.event.pull_request.base.ref == 'main'
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -62,13 +62,15 @@ jobs:
       contents: read
       pull-requests: write
     if: github.event.pull_request.base.ref == 'main'
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803  # v4.8.3
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
@@ -83,7 +85,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
- Bump actions/dependency-review-action from v4.8.3 to v4.9.0
  (SHA: 2031cfc080254a8a887f58cffee85186f0e49e48)
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true env var to opt into
  Node.js 24 runtime ahead of the June 2, 2026 forced migration
- Update bundle-size-check job to use Node.js 24

Fixes deprecation warning: Node.js 20 actions are deprecated.