### PR TITLE
fix: add StatisticsProps type and complete barrel export for Statistics section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4240,9 +4240,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -58,7 +58,7 @@ const statistics: StatisticItem[] = [
 /**
  * Props for the Statistics section component
  */
-export interface StatisticsProps extends Record<string, never> {}
+export type StatisticsProps = Record<string, never>
 
 /**
  * Statistics section displaying animated counters showcasing product metrics

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -69,7 +69,7 @@ export interface StatisticsProps {}
  * - Staggered reveal animations for each stat card
  * - Fully accessible with proper ARIA labels
  */
-export const Statistics: React.FC<StatisticsProps> = () => {
+export const Statistics: React.FC<StatisticsProps> = (_props: StatisticsProps) => {
   return (
     <Section id="statistics" className={styles.statistics} background="primary">
       <div className={styles.container}>

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -56,6 +56,11 @@ const statistics: StatisticItem[] = [
 ]
 
 /**
+ * Props for the Statistics section component
+ */
+export type StatisticsProps = Record<string, never>
+
+/**
  * Statistics section displaying animated counters showcasing product metrics
  *
  * Features:

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -58,7 +58,7 @@ const statistics: StatisticItem[] = [
 /**
  * Props for the Statistics section component
  */
-export type StatisticsProps = Record<string, never>
+export interface StatisticsProps {}
 
 /**
  * Statistics section displaying animated counters showcasing product metrics
@@ -69,7 +69,7 @@ export type StatisticsProps = Record<string, never>
  * - Staggered reveal animations for each stat card
  * - Fully accessible with proper ARIA labels
  */
-export const Statistics = (): React.ReactElement => {
+export const Statistics: React.FC<StatisticsProps> = () => {
   return (
     <Section id="statistics" className={styles.statistics} background="primary">
       <div className={styles.container}>

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -69,7 +69,7 @@ export interface StatisticsProps extends Record<string, never> {}
  * - Staggered reveal animations for each stat card
  * - Fully accessible with proper ARIA labels
  */
-export const Statistics: React.FC<StatisticsProps> = (_props: StatisticsProps) => {
+export const Statistics: React.FC<StatisticsProps> = (_: StatisticsProps) => {
   return (
     <Section id="statistics" className={styles.statistics} background="primary">
       <div className={styles.container}>

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -69,7 +69,7 @@ export type StatisticsProps = Record<string, never>
  * - Staggered reveal animations for each stat card
  * - Fully accessible with proper ARIA labels
  */
-export const Statistics: React.FC<StatisticsProps> = (_: StatisticsProps) => {
+export const Statistics: React.FC<StatisticsProps> = () => {
   return (
     <Section id="statistics" className={styles.statistics} background="primary">
       <div className={styles.container}>

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -69,7 +69,7 @@ export type StatisticsProps = Record<string, never>
  * - Staggered reveal animations for each stat card
  * - Fully accessible with proper ARIA labels
  */
-export const Statistics: React.FC<StatisticsProps> = () => {
+export const Statistics = (): React.ReactElement => {
   return (
     <Section id="statistics" className={styles.statistics} background="primary">
       <div className={styles.container}>

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -58,7 +58,7 @@ const statistics: StatisticItem[] = [
 /**
  * Props for the Statistics section component
  */
-export interface StatisticsProps {}
+export interface StatisticsProps extends Record<string, never> {}
 
 /**
  * Statistics section displaying animated counters showcasing product metrics

--- a/src/components/sections/Statistics/Statistics.tsx
+++ b/src/components/sections/Statistics/Statistics.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Section } from '@components/layout/Section'
 import { AnimatedElement } from '@components/ui/AnimatedElement'
 import { CounterAnimation } from '@components/ui/CounterAnimation'

--- a/src/components/sections/Statistics/index.ts
+++ b/src/components/sections/Statistics/index.ts
@@ -1,1 +1,2 @@
 export { Statistics } from './Statistics'
+export type { StatisticsProps } from './Statistics'


### PR DESCRIPTION
Adds the missing StatisticsProps type export to Statistics.tsx and updates
the barrel index.ts to re-export it, making the Statistics section consistent
with all other section directories. Closes #763.