### PR TITLE
fix: resolve Lighthouse CSP console errors

### DIFF
--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -67,10 +67,15 @@ This file tracks key architectural, design, and technical decisions made during 
 - **Rationale**: Production visibility into errors; filtering prevents accidental PII capture
 - **Alternatives considered**: Datadog, Bugsnag, no monitoring
 
-- **Date**: YYYY-MM-DD (unknown)
-- **Decision**: Vercel Analytics for performance metrics
-- **Rationale**: <1KB, cookie-less performance metrics with a lightweight integration; `@vercel/analytics` is used even when deploying on Netlify
-- **Alternatives considered**: Custom performance tracking
+- **Date**: 2026-04-20
+- **Decision**: Removed `@vercel/analytics` — component stripped from `App.tsx`, dependency removed from `package.json`
+- **Rationale**: Site is deployed on Netlify; `/_vercel/insights/script.js` does not exist there, causing a MIME-type console error that degraded the Lighthouse Best Practices score
+- **Alternatives considered**: Conditional rendering per platform, keeping it for a future Vercel deployment
+
+- **Date**: 2026-04-20 (known pre-existing issue)
+- **Decision**: `worker-src 'none'` in production CSP — Sentry Session Replay likely silently disabled
+- **Rationale**: Sentry `replayIntegration()` is configured in `src/main.tsx` but its web-worker transport is blocked by the current CSP. This is a pre-existing issue unrelated to the CSP/analytics PR. To enable Replay, `worker-src 'self' blob:` would need to be added to both `netlify.toml` and `vercel.json`.
+- **Alternatives considered**: `worker-src 'self' blob:'` (would enable Replay), removing `replayIntegration()` entirely
 
 ## Security
 

--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -82,6 +82,7 @@ This file tracks key architectural, design, and technical decisions made during 
 - **Date**: YYYY-MM-DD (unknown)
 - **Decision**: Two-tier CSP — relaxed in dev (allows unsafe-eval for Vite HMR), strict in prod via hosting-provided HTTP headers (`vercel.json` / `netlify.toml`)
 - **Rationale**: Dev ergonomics vs. production security; CSP meta tags not sufficient for frame-ancestors
+- **Note**: `netlify.toml` and `vercel.json` must always have identical CSP values. Drift between them is a common bug source — any future CSP change must update both files.
 - **Alternatives considered**: Single CSP for both environments
 
 - **Date**: YYYY-MM-DD (unknown)

--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -75,7 +75,7 @@ This file tracks key architectural, design, and technical decisions made during 
 - **Date**: 2026-04-20 (known pre-existing issue)
 - **Decision**: `worker-src 'none'` in production CSP — Sentry Session Replay likely silently disabled
 - **Rationale**: Sentry `replayIntegration()` is configured in `src/main.tsx` but its web-worker transport is blocked by the current CSP. This is a pre-existing issue unrelated to the CSP/analytics PR. To enable Replay, `worker-src 'self' blob:` would need to be added to both `netlify.toml` and `vercel.json`.
-- **Alternatives considered**: `worker-src 'self' blob:'` (would enable Replay), removing `replayIntegration()` entirely
+- **Alternatives considered**: `worker-src 'self' blob:` (would enable Replay), removing `replayIntegration()` entirely
 
 ## Security
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -71,10 +71,8 @@
     # Content Security Policy
     # External origins allowed:
     #   https://plausible.io              Plausible Analytics script + beacon (VITE_ANALYTICS_PROVIDER=plausible)
-    #   https://va.vercel-scripts.com     @vercel/analytics script (rendered unconditionally in App.tsx)
-    #   https://vitals.vercel-insights.com  @vercel/analytics beacon endpoint
     #   https://*.ingest.sentry.io        Sentry error telemetry (VITE_SENTRY_DSN)
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://plausible.io https://va.vercel-scripts.com; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io https://vitals.vercel-insights.com https://*.ingest.sentry.io; worker-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://plausible.io; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io https://*.ingest.sentry.io; worker-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
 
     # Isolate this page's browsing context group so cross-origin windows opened
     # from this page (or that open this page) cannot access each other's DOM or

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@fortawesome/react-fontawesome": "^3.3.0",
         "@sentry/react": "^10.48.0",
         "@testing-library/dom": "^10.4.1",
-        "@vercel/analytics": "^2.0.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -3550,48 +3549,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/react-fontawesome": "^3.3.0",
     "@sentry/react": "^10.48.0",
     "@testing-library/dom": "^10.4.1",
-"react": "^19.2.5",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "@fortawesome/react-fontawesome": "^3.3.0",
     "@sentry/react": "^10.48.0",
     "@testing-library/dom": "^10.4.1",
-    "@vercel/analytics": "^2.0.1",
-    "react": "^19.2.5",
+"react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useRef, useCallback } from 'react'
-import { Analytics } from '@vercel/analytics/react'
 import { ErrorBoundary } from '@components/ErrorBoundary'
 import { Header } from '@components/layout/Header'
 import { Footer } from '@components/layout/Footer'
@@ -55,7 +54,6 @@ function App() {
       </main>
       <Footer />
       <FeedbackWidget />
-      <Analytics />
     </ErrorBoundary>
   )
 }

--- a/src/utils/iconLibrary.test.ts
+++ b/src/utils/iconLibrary.test.ts
@@ -6,6 +6,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
+// Side-effect import: ensures iconLibrary.ts is evaluated so that
+// `config.autoAddCss = false` runs before the CSP Compliance assertion.
+// Kept explicit (rather than relying on the named imports below) so the
+// CSP test cannot regress to passing vacuously if those imports change.
+import './iconLibrary'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import {
   iconNameMap,

--- a/src/utils/iconLibrary.test.ts
+++ b/src/utils/iconLibrary.test.ts
@@ -6,12 +6,14 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { config } from '@fortawesome/fontawesome-svg-core'
+
 // Side-effect import: ensures iconLibrary.ts is evaluated so that
 // `config.autoAddCss = false` runs before the CSP Compliance assertion.
 // Kept explicit (rather than relying on the named imports below) so the
 // CSP test cannot regress to passing vacuously if those imports change.
 import './iconLibrary'
-import { config } from '@fortawesome/fontawesome-svg-core'
 import {
   iconNameMap,
   brandIconNames,

--- a/src/utils/iconLibrary.test.ts
+++ b/src/utils/iconLibrary.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { config } from '@fortawesome/fontawesome-svg-core'
 import {
   iconNameMap,
   brandIconNames,
@@ -190,6 +191,15 @@ describe('iconLibrary', () => {
       values.forEach((iconName) => {
         expect(isValidIcon(iconName)).toBe(true)
       })
+    })
+  })
+
+  describe('CSP Compliance', () => {
+    it('should disable autoAddCss to prevent inline <style> injection blocked by strict CSP', () => {
+      // iconLibrary.ts sets config.autoAddCss = false so FA never injects a
+      // <style> tag at runtime (which would be blocked by style-src 'self').
+      // If this regresses, FA will silently reintroduce CSP console errors.
+      expect(config.autoAddCss).toBe(false)
     })
   })
 

--- a/src/utils/iconLibrary.test.ts
+++ b/src/utils/iconLibrary.test.ts
@@ -6,14 +6,12 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { describe, it, expect } from 'vitest'
-import { config } from '@fortawesome/fontawesome-svg-core'
-
 // Side-effect import: ensures iconLibrary.ts is evaluated so that
 // `config.autoAddCss = false` runs before the CSP Compliance assertion.
 // Kept explicit (rather than relying on the named imports below) so the
 // CSP test cannot regress to passing vacuously if those imports change.
 import './iconLibrary'
+import { config } from '@fortawesome/fontawesome-svg-core'
 import {
   iconNameMap,
   brandIconNames,

--- a/src/utils/iconLibrary.ts
+++ b/src/utils/iconLibrary.ts
@@ -14,11 +14,6 @@
 
 import { library, config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
-
-// Prevent FA from injecting a <style> tag (blocked by strict style-src CSP).
-// The styles.css import above serves the same CSS as a proper bundled stylesheet.
-config.autoAddCss = false
-
 // Solid icons (from free-solid-svg-icons)
 import {
   faBolt, // Lightning Speed feature
@@ -65,7 +60,6 @@ import {
   faArrowLeft, // Navigation back
   faSpinner, // Loading states
 } from '@fortawesome/free-solid-svg-icons'
-
 // Brand icons (from free-brands-svg-icons)
 import {
   faGithub, // GitHub social link
@@ -73,6 +67,12 @@ import {
   faApple, // Apple platform
   faWindows, // Windows platform
 } from '@fortawesome/free-brands-svg-icons'
+
+// Prevent FA from injecting a <style> tag (blocked by strict style-src CSP).
+// The styles.css import above serves the same CSS as a proper bundled stylesheet.
+// Safe to set after the import because FA reads autoAddCss lazily at render
+// time (dom.watch / dom.i2svg), not at module import time.
+config.autoAddCss = false
 
 // Add all icons to the library
 library.add(

--- a/src/utils/iconLibrary.ts
+++ b/src/utils/iconLibrary.ts
@@ -12,7 +12,12 @@
  * 3. Use it in components via the Icon component with the icon name (without 'fa-' prefix)
  */
 
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { library, config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+
+// Prevent FA from injecting a <style> tag (blocked by strict style-src CSP).
+// The styles.css import above serves the same CSS as a proper bundled stylesheet.
+config.autoAddCss = false
 
 // Solid icons (from free-solid-svg-icons)
 import {

--- a/vercel.json
+++ b/vercel.json
@@ -65,7 +65,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=604800"
+          "value": "public, max-age=31536000"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://va.vercel-scripts.com https://plausible.io; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://vitals.vercel-insights.com https://plausible.io https://*.ingest.sentry.io; worker-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
+          "value": "default-src 'self'; script-src 'self' https://plausible.io; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io https://*.ingest.sentry.io; worker-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;"
         },
         {
           "key": "Cross-Origin-Opener-Policy",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,13 +5,6 @@ import path from 'path'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  // @vercel/analytics uses __IS_VERCEL_DEPLOYMENT__ as a build-time constant.
-  // Vite replaces it during production builds, but the test environment does
-  // not — resulting in a ReferenceError when the <Analytics /> component is
-  // rendered in tests. Define it as false so the analytics no-op path is taken.
-  define: {
-    __IS_VERCEL_DEPLOYMENT__: 'false',
-  },
   test: {
     // Use jsdom for browser-like environment
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

This PR performs two CSP-related cleanups:

Removes @vercel/analytics — the site deploys on Netlify, where /_vercel/insights/script.js doesn't exist, causing a MIME-type console error that degraded Lighthouse Best Practices. The dependency, <Analytics /> component, CSP allowlist entries, and the Vite test shim are all removed.

Fixes FontAwesome inline-style CSP violation — FontAwesome's default behaviour injects a <style> tag at runtime, which is blocked by style-src 'self'. The fix:

// iconLibrary.ts
import { config } from '...fontawesome-svg-core'
import '...fontawesome-svg-core/styles.css'
config.autoAddCss = false
A regression test asserts config.autoAddCss === false.

Both netlify.toml and vercel.json CSP headers are updated in lockstep, with a decision-log note to keep them in sync.

## Changes

- Font Awesome (v7) injects a <style> tag that was blocked by
  style-src 'self'. Fix by setting config.autoAddCss = false and
  importing @fortawesome/fontawesome-svg-core/styles.css so Vite
  bundles the styles as a proper external stylesheet.

- Remove <Analytics /> from @vercel/analytics/react: on Netlify the
  /_vercel/insights/script.js path doesn't exist, so Netlify returns
  an HTML 404, causing a MIME-type mismatch error in the console.

- Drop va.vercel-scripts.com and vitals.vercel-insights.com from the
  CSP script-src/connect-src in both netlify.toml and vercel.json
  now that @vercel/analytics is no longer used.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shazzar00ni/paperlyte-v2/pull/781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
