### PR TITLE
feat: add three new analytics providers and resolve placeholder TODOs

### DIFF
--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -149,6 +149,29 @@ The following metrics are tracked automatically when analytics is enabled:
   VITE_ANALYTICS_DOMAIN=YOUR_SITE_ID
   ```
 
+- **Custom events**: Fathom uses provider-assigned **goal codes** (short IDs created in
+  the Fathom dashboard, e.g. `ABCD1234`), not arbitrary event names. Custom events
+  whose names are not present in `config.goalCodes` are skipped. `getAnalyticsConfig()`
+  does not populate `goalCodes` from environment variables; you must augment the
+  config when calling `analytics.init()`:
+
+  ```tsx
+  const config = getAnalyticsConfig()
+  if (config) {
+    analytics.init({
+      ...config,
+      goalCodes: {
+        cta_click: 'ABCD1234',
+        scroll_depth: 'EFGH5678',
+        download_click: 'IJKL9012',
+      },
+    })
+  }
+  ```
+
+  Web Vitals are not forwarded to Fathom (they would require dedicated goal codes
+  per metric); use a different provider if Web Vitals tracking is important to you.
+
 ### Umami (Self-Hosted)
 
 - **Website**: <https://umami.is>
@@ -286,7 +309,11 @@ src/analytics/
 ├── webVitals.ts          # Core Web Vitals tracking
 ├── scrollDepth.ts        # Scroll depth monitoring
 ├── providers/
-│   └── plausible.ts      # Plausible provider implementation
+│   ├── plausible.ts      # Plausible provider implementation
+│   ├── fathom.ts         # Fathom provider implementation
+│   ├── umami.ts          # Umami provider implementation
+│   ├── simple.ts         # Simple Analytics provider implementation
+│   └── utils.ts          # Shared provider helpers (DNT, URL validation)
 └── README.md             # This file
 
 src/hooks/

--- a/src/analytics/index.test.ts
+++ b/src/analytics/index.test.ts
@@ -82,10 +82,26 @@ describe('analytics/index', () => {
       expect(script.src).toContain('plausible')
     })
 
-    it('should throw error for unimplemented providers', () => {
-      const fathomConfig = { ...config, provider: 'fathom' as const }
+    it('should throw error for custom provider (requires user implementation)', () => {
+      const customConfig = { ...config, provider: 'custom' as const }
 
-      expect(() => analytics.init(fathomConfig)).toThrow('Provider "fathom" is not yet implemented')
+      expect(() => analytics.init(customConfig)).toThrow(
+        'Provider "custom" requires a custom implementation'
+      )
+    })
+
+    it('should initialize without throwing for fathom, umami, and simple providers', () => {
+      const providers = ['fathom', 'umami', 'simple'] as const
+      for (const provider of providers) {
+        analytics.reset()
+        document.head.innerHTML = ''
+        const providerConfig = {
+          ...config,
+          provider,
+          scriptUrl: 'https://cdn.example.com/script.js',
+        }
+        expect(() => analytics.init(providerConfig)).not.toThrow()
+      }
     })
 
     it('should fallback to Plausible for unknown providers', () => {

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -106,7 +106,7 @@ class Analytics {
         if (import.meta.env.DEV) {
           console.warn(
             `[Analytics] Unknown provider "${provider}", falling back to Plausible. ` +
-              `Supported providers: plausible, fathom, umami, simple`
+              `Supported built-in providers: plausible, fathom, umami, simple`
           )
         }
         return new PlausibleProvider()

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -97,8 +97,12 @@ class Analytics {
       case 'simple':
         return new SimpleAnalyticsProvider()
       case 'custom':
+        throw new Error(
+          `[Analytics] Provider "custom" requires a custom implementation. ` +
+            `Extend AnalyticsProvider and wire it in before calling analytics.init().`
+        )
       default:
-        // Fallback to Plausible for any other value (with warning in dev)
+        // Fallback to Plausible for any unknown value (with warning in dev)
         if (import.meta.env.DEV) {
           console.warn(
             `[Analytics] Unknown provider "${provider}", falling back to Plausible. ` +

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -23,6 +23,9 @@
 
 import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider } from './types'
 import { PlausibleProvider } from './providers/plausible'
+import { FathomProvider } from './providers/fathom'
+import { UmamiProvider } from './providers/umami'
+import { SimpleAnalyticsProvider } from './providers/simple'
 import { initWebVitals } from './webVitals'
 import { createScrollTracker } from './scrollDepth'
 
@@ -88,24 +91,18 @@ class Analytics {
       case 'plausible':
         return new PlausibleProvider()
       case 'fathom':
+        return new FathomProvider()
       case 'umami':
+        return new UmamiProvider()
       case 'simple':
+        return new SimpleAnalyticsProvider()
       case 'custom':
-        // TODO: Implement additional analytics providers
-        // Track progress at: https://github.com/shazzar00ni/paperlyte-v2/issues/[ISSUE_NUMBER]
-        // Required providers: Fathom, Umami, Simple Analytics, Custom
-        // See src/analytics/README.md for implementation requirements
-        throw new Error(
-          `[Analytics] Provider "${provider}" is not yet implemented. ` +
-            `Please use "plausible" for now. ` +
-            `Track implementation progress at: https://github.com/shazzar00ni/paperlyte-v2/issues`
-        )
       default:
         // Fallback to Plausible for any other value (with warning in dev)
         if (import.meta.env.DEV) {
           console.warn(
             `[Analytics] Unknown provider "${provider}", falling back to Plausible. ` +
-              `Supported providers: plausible`
+              `Supported providers: plausible, fathom, umami, simple`
           )
         }
         return new PlausibleProvider()

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -294,36 +294,37 @@ describe('analytics/providers/fathom', () => {
       script.onload?.(new Event('load'))
     })
 
-    it('should track each defined Core Web Vitals metric', () => {
+    it('should not call trackGoal (Fathom requires explicit goal codes for web vitals)', () => {
       const vitals: CoreWebVitals = { LCP: 2500, CLS: 0.12345, FCP: 1800 }
       provider.trackWebVitals(vitals)
 
-      expect(window.fathom!.trackGoal).toHaveBeenCalledTimes(3)
-      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('web_vitals', 0, {
-        metric: 'LCP',
-        value: 2500,
-      })
-      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('web_vitals', 0, {
-        metric: 'CLS',
-        value: 0.123,
-      })
+      expect(window.fathom!.trackGoal).not.toHaveBeenCalled()
     })
 
-    it('should skip undefined metrics', () => {
-      const vitals: CoreWebVitals = { LCP: 2500, FID: undefined }
-      provider.trackWebVitals(vitals)
+    it('should log a debug warning when metrics are present and debug is enabled', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      document.head.innerHTML = ''
+      Object.defineProperty(window, 'doNotTrack', { writable: true, configurable: true, value: null })
+      const debugProvider = new FathomProvider()
+      debugProvider.init({ ...config, debug: true })
+      window.fathom = mockFathom()
 
-      expect(window.fathom!.trackGoal).toHaveBeenCalledTimes(1)
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      debugProvider.trackWebVitals({ LCP: 2500, CLS: 0.12345 })
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Fathom does not track Web Vitals')
+      )
+      consoleWarnSpy.mockRestore()
     })
 
-    it('should not track when provider is not enabled', () => {
-      provider.disable()
-      const fathomMock = mockFathom()
-      window.fathom = fathomMock
-
-      provider.trackWebVitals({ LCP: 2500 })
-
-      expect(fathomMock.trackGoal).not.toHaveBeenCalled()
+    it('should not log a warning when no metrics are defined', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.trackWebVitals({ LCP: undefined, FID: undefined })
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
     })
   })
 

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -192,6 +192,20 @@ describe('analytics/providers/fathom', () => {
       provider.init(config)
       expect(document.querySelector('script[data-site]')).toBeNull()
     })
+
+    it('should not inject a second script when loadScript is called while already loaded', () => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      // scriptLoaded is now true; manually trigger loadScript via the internal state path
+      ;(provider as unknown as { loadScript: () => void }).loadScript()
+
+      // Only one script should be in the DOM
+      expect(document.querySelectorAll('script[data-site]').length).toBe(1)
+    })
   })
 
   describe('trackPageView', () => {
@@ -384,6 +398,17 @@ describe('analytics/providers/fathom', () => {
       provider.trackWebVitals(vitals)
 
       expect(window.fathom!.trackGoal).not.toHaveBeenCalled()
+    })
+
+    it('should return early when provider is not enabled', () => {
+      provider.disable()
+      const fathomMock = mockFathom()
+      window.fathom = fathomMock
+
+      // No throw and no trackGoal call – covers the isEnabled() early-return branch
+      provider.trackWebVitals({ LCP: 2500, CLS: 0.1 })
+
+      expect(fathomMock.trackGoal).not.toHaveBeenCalled()
     })
 
     it('should log a debug warning when metrics are present and debug is enabled', () => {

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -59,7 +59,6 @@ describe('analytics/providers/fathom', () => {
       expect(script.src).toBe('https://cdn.usefathom.com/script.js')
       expect(script.getAttribute('data-site')).toBe('ABCDEFGH')
       expect(script.async).toBe(true)
-      expect(script.defer).toBe(true)
     })
 
     it('should use a valid custom scriptUrl', () => {
@@ -249,10 +248,14 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should block prototype pollution via __proto__', () => {
-      const event: AnalyticsEvent = {
-        name: 'ABCD1234',
-        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
-      }
+      const properties: Record<string, unknown> = { safe: 'ok' }
+      Object.defineProperty(properties, '__proto__', {
+        value: { bad: true },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+      const event: AnalyticsEvent = { name: 'ABCD1234', properties }
       provider.trackEvent(event)
 
       expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, { safe: 'ok' })

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for Fathom Analytics provider
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { FathomProvider } from './fathom'
+import type { AnalyticsConfig, AnalyticsEvent, CoreWebVitals } from '../types'
+
+describe('analytics/providers/fathom', () => {
+  let provider: FathomProvider
+  let config: AnalyticsConfig
+
+  const mockFathom = () => ({
+    trackPageview: vi.fn(),
+    trackGoal: vi.fn(),
+    enableTrackingForMe: vi.fn(),
+    blockTrackingForMe: vi.fn(),
+  })
+
+  beforeEach(() => {
+    provider = new FathomProvider()
+
+    config = {
+      provider: 'fathom',
+      domain: 'ABCDEFGH',
+      debug: false,
+      trackPageviews: true,
+      trackWebVitals: true,
+      trackScrollDepth: true,
+      respectDNT: true,
+    }
+
+    delete window.fathom
+    document.head.innerHTML = ''
+
+    Object.defineProperty(navigator, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('init', () => {
+    it('should inject script with default URL and data-site attribute', () => {
+      provider.init(config)
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      expect(script).toBeTruthy()
+      expect(script.src).toBe('https://cdn.usefathom.com/script.js')
+      expect(script.getAttribute('data-site')).toBe('ABCDEFGH')
+      expect(script.async).toBe(true)
+      expect(script.defer).toBe(true)
+    })
+
+    it('should use a valid custom scriptUrl', () => {
+      const customConfig = { ...config, scriptUrl: 'https://custom.cdn.com/fathom.js' }
+      provider.init(customConfig)
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      expect(script.src).toBe('https://custom.cdn.com/fathom.js')
+    })
+
+    it('should fall back to default URL for invalid scriptUrl (non-HTTPS)', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true, scriptUrl: 'http://insecure.com/script.js' }
+      provider.init(debugConfig)
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      expect(script.src).toBe('https://cdn.usefathom.com/script.js')
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Analytics] Invalid Fathom scriptUrl, falling back to default'
+      )
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should fall back to default URL for invalid scriptUrl (no .js extension)', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true, scriptUrl: 'https://example.com/tracker' }
+      provider.init(debugConfig)
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      expect(script.src).toBe('https://cdn.usefathom.com/script.js')
+      expect(consoleWarnSpy).toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should not initialize twice', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true }
+
+      provider.init(debugConfig)
+      provider.init(debugConfig)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Fathom already initialized')
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should not initialize when Do Not Track is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true }
+
+      provider.init(debugConfig)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Analytics] Do Not Track is enabled, analytics disabled'
+      )
+      expect(document.querySelector('script[data-site]')).toBeNull()
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should ignore DNT when respectDNT is false', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+
+      provider.init({ ...config, respectDNT: false })
+
+      expect(document.querySelector('script[data-site]')).toBeTruthy()
+    })
+
+    it('should handle script load success', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      window.fathom = mockFathom()
+      script.onload?.(new Event('load'))
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Fathom script loaded successfully')
+      expect(provider.isEnabled()).toBe(true)
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should handle script load error', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onerror?.(new Event('error'))
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[Analytics] Failed to load Fathom script')
+      expect(provider.isEnabled()).toBe(false)
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should detect window.doNotTrack', () => {
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
+
+      provider.init(config)
+      expect(document.querySelector('script[data-site]')).toBeNull()
+    })
+
+    it('should detect navigator.doNotTrack = "yes"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: 'yes' })
+
+      provider.init(config)
+      expect(document.querySelector('script[data-site]')).toBeNull()
+    })
+  })
+
+  describe('trackPageView', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track page view with current pathname by default', () => {
+      provider.trackPageView()
+
+      expect(window.fathom!.trackPageview).toHaveBeenCalledWith({
+        url: window.location.pathname,
+      })
+    })
+
+    it('should track page view with custom URL', () => {
+      provider.trackPageView('/custom-page')
+
+      expect(window.fathom!.trackPageview).toHaveBeenCalledWith({ url: '/custom-page' })
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const fathomMock = mockFathom()
+      window.fathom = fathomMock
+
+      provider.trackPageView()
+
+      expect(fathomMock.trackPageview).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trackEvent', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should call trackGoal with event name and zero value', () => {
+      const event: AnalyticsEvent = { name: 'ABCD1234' }
+      provider.trackEvent(event)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, undefined)
+    })
+
+    it('should pass sanitised properties to trackGoal', () => {
+      const event: AnalyticsEvent = {
+        name: 'ABCD1234',
+        properties: { button: 'Join Waitlist', count: 1 },
+      }
+      provider.trackEvent(event)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, {
+        button: 'Join Waitlist',
+        count: 1,
+      })
+    })
+
+    it('should filter out null and undefined properties', () => {
+      const event: AnalyticsEvent = {
+        name: 'ABCD1234',
+        properties: {
+          valid: 'value',
+          nullProp: null as unknown as string,
+          undefinedProp: undefined,
+        },
+      }
+      provider.trackEvent(event)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, { valid: 'value' })
+    })
+
+    it('should block prototype pollution via __proto__', () => {
+      const event: AnalyticsEvent = {
+        name: 'ABCD1234',
+        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
+      }
+      provider.trackEvent(event)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, { safe: 'ok' })
+    })
+
+    it('should log debug message when debug is enabled', () => {
+      document.head.innerHTML = ''
+      const debugProvider = new FathomProvider()
+      debugProvider.init({ ...config, debug: true })
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      debugProvider.trackEvent({ name: 'ABCD1234' })
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Fathom trackGoal'))
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const fathomMock = mockFathom()
+      window.fathom = fathomMock
+
+      provider.trackEvent({ name: 'ABCD1234' })
+
+      expect(fathomMock.trackGoal).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trackWebVitals', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track each defined Core Web Vitals metric', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, CLS: 0.12345, FCP: 1800 }
+      provider.trackWebVitals(vitals)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledTimes(3)
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('web_vitals', 0, {
+        metric: 'LCP',
+        value: 2500,
+      })
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('web_vitals', 0, {
+        metric: 'CLS',
+        value: 0.123,
+      })
+    })
+
+    it('should skip undefined metrics', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, FID: undefined }
+      provider.trackWebVitals(vitals)
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const fathomMock = mockFathom()
+      window.fathom = fathomMock
+
+      provider.trackWebVitals({ LCP: 2500 })
+
+      expect(fathomMock.trackGoal).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isEnabled', () => {
+    it('should return false when not initialized', () => {
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return false when script not yet loaded', () => {
+      provider.init(config)
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return true when initialized and script loaded', () => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      expect(provider.isEnabled()).toBe(true)
+    })
+
+    it('should return false after disable', () => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(provider.isEnabled()).toBe(false)
+    })
+  })
+
+  describe('disable', () => {
+    it('should reset state and remove script', () => {
+      provider.init(config)
+      expect(document.querySelector('script[data-site]')).toBeTruthy()
+
+      provider.disable()
+
+      expect(document.querySelector('script[data-site]')).toBeNull()
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should delete window.fathom', () => {
+      provider.init(config)
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(window.fathom).toBeUndefined()
+    })
+
+    it('should log debug message when debug is enabled', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugProvider = new FathomProvider()
+      debugProvider.init({ ...config, debug: true })
+
+      debugProvider.disable()
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Fathom disabled')
+      consoleLogSpy.mockRestore()
+    })
+  })
+})

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -38,6 +38,12 @@ describe('analytics/providers/fathom', () => {
       configurable: true,
       value: null,
     })
+
+    Object.defineProperty(window, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
   })
 
   afterEach(() => {

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -126,6 +126,30 @@ describe('analytics/providers/fathom', () => {
       expect(document.querySelector('script[data-site]')).toBeTruthy()
     })
 
+    it('should warn when trackPageviews is false because Fathom cannot suppress the initial pageview', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      provider.init({ ...config, debug: true, trackPageviews: false })
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Fathom does not support disabling automatic pageview tracking')
+      )
+      // Script is still injected — the limitation is documented, not a hard block
+      expect(document.querySelector('script[data-site]')).toBeTruthy()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should not warn about trackPageviews when trackPageviews is true', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      provider.init({ ...config, debug: true, trackPageviews: true })
+
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Fathom does not support disabling automatic pageview tracking')
+      )
+      consoleWarnSpy.mockRestore()
+    })
+
     it('should handle script load success', () => {
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       provider.init({ ...config, debug: true })

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -6,6 +6,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { FathomProvider } from './fathom'
 import type { AnalyticsConfig, AnalyticsEvent, CoreWebVitals } from '../types'
 
+const removeFathomScripts = (): void => {
+  document.querySelectorAll('script[data-site]').forEach((el) => el.remove())
+}
+
 describe('analytics/providers/fathom', () => {
   let provider: FathomProvider
   let config: AnalyticsConfig
@@ -31,7 +35,7 @@ describe('analytics/providers/fathom', () => {
     }
 
     delete window.fathom
-    document.head.innerHTML = ''
+    removeFathomScripts()
 
     Object.defineProperty(navigator, 'doNotTrack', {
       writable: true,
@@ -265,7 +269,7 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should skip and warn when event name has no goal code mapping (debug mode)', () => {
-      document.head.innerHTML = ''
+      removeFathomScripts()
       const warnProvider = new FathomProvider()
       warnProvider.init({ ...config, debug: true, goalCodes: {} })
       window.fathom = mockFathom()
@@ -284,7 +288,7 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should skip silently when event name has no goal code mapping (non-debug mode)', () => {
-      document.head.innerHTML = ''
+      removeFathomScripts()
       const silentProvider = new FathomProvider()
       silentProvider.init({ ...config, debug: false, goalCodes: {} })
       window.fathom = mockFathom()
@@ -301,7 +305,7 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should skip when no goalCodes config is provided at all', () => {
-      document.head.innerHTML = ''
+      removeFathomScripts()
       const noMapProvider = new FathomProvider()
       noMapProvider.init(config) // no goalCodes
       window.fathom = mockFathom()
@@ -356,7 +360,7 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should log debug message with goal code when debug is enabled', () => {
-      document.head.innerHTML = ''
+      removeFathomScripts()
       const debugProvider = new FathomProvider()
       debugProvider.init({ ...config, debug: true, goalCodes: { cta_click: 'GOAL1234' } })
       window.fathom = mockFathom()
@@ -367,9 +371,7 @@ describe('analytics/providers/fathom', () => {
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       debugProvider.trackEvent({ name: 'cta_click' })
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Fathom trackGoal')
-      )
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Fathom trackGoal'))
       consoleLogSpy.mockRestore()
     })
 
@@ -413,7 +415,7 @@ describe('analytics/providers/fathom', () => {
 
     it('should log a debug warning when metrics are present and debug is enabled', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      document.head.innerHTML = ''
+      removeFathomScripts()
       Object.defineProperty(window, 'doNotTrack', {
         writable: true,
         configurable: true,
@@ -437,7 +439,7 @@ describe('analytics/providers/fathom', () => {
     it('should not log a warning when no metrics are defined (debug enabled)', () => {
       // Use debug: true so the "skipped metrics" branch is actually entered;
       // the assertion then meaningfully verifies that an empty vitals object produces no warning.
-      document.head.innerHTML = ''
+      removeFathomScripts()
       const debugProvider = new FathomProvider()
       debugProvider.init({ ...config, debug: true })
       window.fathom = mockFathom()

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -363,6 +363,19 @@ describe('analytics/providers/fathom', () => {
 
       expect(provider.isEnabled()).toBe(false)
     })
+
+    it('should return false when window.fathom exists but methods are not functions', () => {
+      provider.init(config)
+      window.fathom = {
+        trackPageview: 'not-a-function',
+        trackGoal: 'not-a-function',
+      } as unknown as typeof window.fathom
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      expect(provider.isEnabled()).toBe(false)
+    })
   })
 
   describe('disable', () => {

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -230,18 +230,74 @@ describe('analytics/providers/fathom', () => {
 
   describe('trackEvent', () => {
     beforeEach(() => {
-      provider.init(config)
+      provider.init({ ...config, goalCodes: { ABCD1234: 'ABCD1234', cta_click: 'WXYZ9876' } })
       window.fathom = mockFathom()
 
       const script = document.querySelector('script[data-site]') as HTMLScriptElement
       script.onload?.(new Event('load'))
     })
 
-    it('should call trackGoal with event name and zero value', () => {
+    it('should call trackGoal with the mapped goal code and zero value', () => {
       const event: AnalyticsEvent = { name: 'ABCD1234' }
       provider.trackEvent(event)
 
       expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, undefined)
+    })
+
+    it('should resolve the goal code from the event name mapping', () => {
+      provider.trackEvent({ name: 'cta_click' })
+
+      expect(window.fathom!.trackGoal).toHaveBeenCalledWith('WXYZ9876', 0, undefined)
+    })
+
+    it('should skip and warn when event name has no goal code mapping (debug mode)', () => {
+      document.head.innerHTML = ''
+      const warnProvider = new FathomProvider()
+      warnProvider.init({ ...config, debug: true, goalCodes: {} })
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      warnProvider.trackEvent({ name: 'scroll_depth' })
+
+      expect(window.fathom!.trackGoal).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no goal code mapped for event "scroll_depth"')
+      )
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should skip silently when event name has no goal code mapping (non-debug mode)', () => {
+      document.head.innerHTML = ''
+      const silentProvider = new FathomProvider()
+      silentProvider.init({ ...config, debug: false, goalCodes: {} })
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      silentProvider.trackEvent({ name: 'scroll_depth' })
+
+      expect(window.fathom!.trackGoal).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should skip when no goalCodes config is provided at all', () => {
+      document.head.innerHTML = ''
+      const noMapProvider = new FathomProvider()
+      noMapProvider.init(config) // no goalCodes
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      noMapProvider.trackEvent({ name: 'ABCD1234' })
+
+      expect(window.fathom!.trackGoal).not.toHaveBeenCalled()
     })
 
     it('should pass sanitised properties to trackGoal', () => {
@@ -285,10 +341,10 @@ describe('analytics/providers/fathom', () => {
       expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, { safe: 'ok' })
     })
 
-    it('should log debug message when debug is enabled', () => {
+    it('should log debug message with goal code when debug is enabled', () => {
       document.head.innerHTML = ''
       const debugProvider = new FathomProvider()
-      debugProvider.init({ ...config, debug: true })
+      debugProvider.init({ ...config, debug: true, goalCodes: { ABCD1234: 'ABCD1234' } })
       window.fathom = mockFathom()
 
       const script = document.querySelector('script[data-site]') as HTMLScriptElement

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -230,7 +230,7 @@ describe('analytics/providers/fathom', () => {
 
   describe('trackEvent', () => {
     beforeEach(() => {
-      provider.init({ ...config, goalCodes: { ABCD1234: 'ABCD1234', cta_click: 'WXYZ9876' } })
+      provider.init({ ...config, goalCodes: { example_event: 'ABCD1234', cta_click: 'WXYZ9876' } })
       window.fathom = mockFathom()
 
       const script = document.querySelector('script[data-site]') as HTMLScriptElement
@@ -238,7 +238,7 @@ describe('analytics/providers/fathom', () => {
     })
 
     it('should call trackGoal with the mapped goal code and zero value', () => {
-      const event: AnalyticsEvent = { name: 'ABCD1234' }
+      const event: AnalyticsEvent = { name: 'example_event' }
       provider.trackEvent(event)
 
       expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, undefined)
@@ -302,7 +302,7 @@ describe('analytics/providers/fathom', () => {
 
     it('should pass sanitised properties to trackGoal', () => {
       const event: AnalyticsEvent = {
-        name: 'ABCD1234',
+        name: 'example_event',
         properties: { button: 'Join Waitlist', count: 1 },
       }
       provider.trackEvent(event)
@@ -315,7 +315,7 @@ describe('analytics/providers/fathom', () => {
 
     it('should filter out null and undefined properties', () => {
       const event: AnalyticsEvent = {
-        name: 'ABCD1234',
+        name: 'example_event',
         properties: {
           valid: 'value',
           nullProp: null as unknown as string,
@@ -335,7 +335,7 @@ describe('analytics/providers/fathom', () => {
         configurable: true,
         writable: true,
       })
-      const event: AnalyticsEvent = { name: 'ABCD1234', properties }
+      const event: AnalyticsEvent = { name: 'example_event', properties }
       provider.trackEvent(event)
 
       expect(window.fathom!.trackGoal).toHaveBeenCalledWith('ABCD1234', 0, { safe: 'ok' })
@@ -344,16 +344,18 @@ describe('analytics/providers/fathom', () => {
     it('should log debug message with goal code when debug is enabled', () => {
       document.head.innerHTML = ''
       const debugProvider = new FathomProvider()
-      debugProvider.init({ ...config, debug: true, goalCodes: { ABCD1234: 'ABCD1234' } })
+      debugProvider.init({ ...config, debug: true, goalCodes: { cta_click: 'GOAL1234' } })
       window.fathom = mockFathom()
 
       const script = document.querySelector('script[data-site]') as HTMLScriptElement
       script.onload?.(new Event('load'))
 
       const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      debugProvider.trackEvent({ name: 'ABCD1234' })
+      debugProvider.trackEvent({ name: 'cta_click' })
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Fathom trackGoal'))
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Fathom trackGoal')
+      )
       consoleLogSpy.mockRestore()
     })
 

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -409,9 +409,19 @@ describe('analytics/providers/fathom', () => {
       consoleWarnSpy.mockRestore()
     })
 
-    it('should not log a warning when no metrics are defined', () => {
+    it('should not log a warning when no metrics are defined (debug enabled)', () => {
+      // Use debug: true so the "skipped metrics" branch is actually entered;
+      // the assertion then meaningfully verifies that an empty vitals object produces no warning.
+      document.head.innerHTML = ''
+      const debugProvider = new FathomProvider()
+      debugProvider.init({ ...config, debug: true })
+      window.fathom = mockFathom()
+
+      const script = document.querySelector('script[data-site]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      provider.trackWebVitals({ LCP: undefined, FID: undefined })
+      debugProvider.trackWebVitals({ LCP: undefined, FID: undefined })
       expect(consoleWarnSpy).not.toHaveBeenCalled()
       consoleWarnSpy.mockRestore()
     })

--- a/src/analytics/providers/fathom.test.ts
+++ b/src/analytics/providers/fathom.test.ts
@@ -304,7 +304,11 @@ describe('analytics/providers/fathom', () => {
     it('should log a debug warning when metrics are present and debug is enabled', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       document.head.innerHTML = ''
-      Object.defineProperty(window, 'doNotTrack', { writable: true, configurable: true, value: null })
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: null,
+      })
       const debugProvider = new FathomProvider()
       debugProvider.init({ ...config, debug: true })
       window.fathom = mockFathom()

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -183,8 +183,10 @@ export class FathomProvider implements AnalyticsProvider {
     this.scriptLoaded = false
     this.config = null
 
-    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
-      this.scriptElement.parentNode.removeChild(this.scriptElement)
+    if (typeof document !== 'undefined' && this.scriptElement) {
+      if (this.scriptElement.parentNode) {
+        this.scriptElement.parentNode.removeChild(this.scriptElement)
+      }
       this.scriptElement = null
     }
 

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -64,11 +64,11 @@ export class FathomProvider implements AnalyticsProvider {
 
     const script = document.createElement('script')
     script.async = true
-    script.defer = true
     script.src = scriptUrl
     script.setAttribute('data-site', this.config?.domain || '')
 
     script.onerror = () => {
+      if (this.scriptElement !== script) return
       if (this.config?.debug) {
         console.warn('[Analytics] Failed to load Fathom script')
       }
@@ -76,6 +76,7 @@ export class FathomProvider implements AnalyticsProvider {
     }
 
     script.onload = () => {
+      if (this.scriptElement !== script) return
       this.scriptLoaded = true
       if (this.config?.debug) {
         console.log('[Analytics] Fathom script loaded successfully')

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -55,30 +55,13 @@ export class FathomProvider implements AnalyticsProvider {
     }
 
     const defaultUrl = 'https://cdn.usefathom.com/script.js'
-  private isValidScriptUrl(scriptUrl: string): boolean {
-    try {
-      const parsedUrl = new URL(scriptUrl)
-      return parsedUrl.protocol === 'https:' && parsedUrl.pathname.endsWith('.js')
-    } catch {
-      return false
-    }
-  }
+    const configured = this.config?.scriptUrl
+    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
 
-  private loadScript(): void {
-    if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
-      return
+    if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
+      console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
     }
 
-    const defaultScriptUrl = 'https://cdn.usefathom.com/script.js'
-    const configuredScriptUrl = this.config?.scriptUrl
-    const scriptUrl =
-      configuredScriptUrl && this.isValidScriptUrl(configuredScriptUrl)
-        ? configuredScriptUrl
-        : defaultScriptUrl
-
-    if (configuredScriptUrl && scriptUrl !== configuredScriptUrl && this.config?.debug) {
-      console.warn('[Analytics] Invalid Fathom script URL configured, falling back to default script')
-    }
     const script = document.createElement('script')
     script.async = true
     script.defer = true

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -40,12 +40,27 @@ export class FathomProvider implements AnalyticsProvider {
     this.loadScript()
   }
 
+  private isValidScriptUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
+    } catch {
+      return false
+    }
+  }
+
   private loadScript(): void {
     if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
       return
     }
 
-    const scriptUrl = this.config?.scriptUrl || 'https://cdn.usefathom.com/script.js'
+    const defaultUrl = 'https://cdn.usefathom.com/script.js'
+    const configured = this.config?.scriptUrl
+    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
+
+    if (configured && scriptUrl !== configured && this.config?.debug) {
+      console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
+    }
 
     const script = document.createElement('script')
     script.async = true
@@ -85,9 +100,16 @@ export class FathomProvider implements AnalyticsProvider {
       return
     }
 
-    // Fathom uses goal codes (short IDs) rather than arbitrary names.
-    // We encode the event name as the goal code and pass a value of 0.
-    // Properties are JSON-encoded and sent as a custom value where supported.
+    // Fathom uses provider-assigned goal codes (e.g. "ABCD1234"), not arbitrary strings.
+    // Using event.name as the code will silently drop events unless it matches a real goal ID.
+    // Create matching goals in the Fathom dashboard and pass their codes as event names.
+    if (this.config?.debug) {
+      console.log(
+        `[Analytics] Fathom trackGoal called with code "${event.name}". ` +
+          `Ensure this matches a goal code defined in your Fathom dashboard.`
+      )
+    }
+
     const props = event.properties
       ? Object.entries(event.properties).reduce(
           (acc, [key, value]) => {

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -9,6 +9,7 @@
 
 import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
 import { isSafePropertyKey } from '../../utils/security'
+import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 /**
  * Fathom Analytics provider
@@ -28,7 +29,7 @@ export class FathomProvider implements AnalyticsProvider {
       return
     }
 
-    if (config.respectDNT !== false && this.isDNTEnabled()) {
+    if (config.respectDNT !== false && isDNTEnabled()) {
       if (config.debug) {
         console.log('[Analytics] Do Not Track is enabled, analytics disabled')
       }
@@ -40,15 +41,6 @@ export class FathomProvider implements AnalyticsProvider {
     this.loadScript()
   }
 
-  private isValidScriptUrl(url: string): boolean {
-    try {
-      const parsed = new URL(url)
-      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
-    } catch {
-      return false
-    }
-  }
-
   private loadScript(): void {
     if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
       return
@@ -56,7 +48,7 @@ export class FathomProvider implements AnalyticsProvider {
 
     const defaultUrl = 'https://cdn.usefathom.com/script.js'
     const configured = this.config?.scriptUrl
-    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
+    const scriptUrl = configured && isValidScriptUrl(configured) ? configured : defaultUrl
 
     if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
       console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
@@ -195,16 +187,4 @@ export class FathomProvider implements AnalyticsProvider {
     }
   }
 
-  private isDNTEnabled(): boolean {
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return false
-    }
-
-    const dnt =
-      navigator.doNotTrack ||
-      (window as Window & { doNotTrack?: string }).doNotTrack ||
-      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
-
-    return dnt === '1' || dnt === 'yes'
-  }
 }

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -1,0 +1,168 @@
+/**
+ * Fathom Analytics provider implementation
+ *
+ * Privacy-focused, cookie-less analytics that's GDPR compliant.
+ * Lightweight script with async loading for minimal performance impact.
+ *
+ * @see https://usefathom.com/docs
+ */
+
+import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
+import { isSafePropertyKey } from '../../utils/security'
+
+/**
+ * Fathom Analytics provider
+ * Implements privacy-first, cookie-less analytics tracking
+ */
+export class FathomProvider implements AnalyticsProvider {
+  private config: AnalyticsConfig | null = null
+  private initialized = false
+  private scriptLoaded = false
+  private scriptElement: HTMLScriptElement | null = null
+
+  init(config: AnalyticsConfig): void {
+    if (this.initialized) {
+      if (config.debug) {
+        console.log('[Analytics] Fathom already initialized')
+      }
+      return
+    }
+
+    if (config.respectDNT !== false && this.isDNTEnabled()) {
+      if (config.debug) {
+        console.log('[Analytics] Do Not Track is enabled, analytics disabled')
+      }
+      return
+    }
+
+    this.config = config
+    this.initialized = true
+    this.loadScript()
+  }
+
+  private loadScript(): void {
+    if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const scriptUrl = this.config?.scriptUrl || 'https://cdn.usefathom.com/script.js'
+
+    const script = document.createElement('script')
+    script.async = true
+    script.defer = true
+    script.src = scriptUrl
+    script.setAttribute('data-site', this.config?.domain || '')
+
+    script.onerror = () => {
+      if (this.config?.debug) {
+        console.warn('[Analytics] Failed to load Fathom script')
+      }
+      this.scriptLoaded = false
+    }
+
+    script.onload = () => {
+      this.scriptLoaded = true
+      if (this.config?.debug) {
+        console.log('[Analytics] Fathom script loaded successfully')
+      }
+    }
+
+    this.scriptElement = script
+    document.head.appendChild(script)
+  }
+
+  trackPageView(url?: string): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.fathom) {
+      return
+    }
+
+    const pageUrl = url || window.location.pathname
+    window.fathom.trackPageview({ url: pageUrl })
+  }
+
+  trackEvent(event: AnalyticsEvent): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.fathom) {
+      return
+    }
+
+    // Fathom uses goal codes (short IDs) rather than arbitrary names.
+    // We encode the event name as the goal code and pass a value of 0.
+    // Properties are JSON-encoded and sent as a custom value where supported.
+    const props = event.properties
+      ? Object.entries(event.properties).reduce(
+          (acc, [key, value]) => {
+            if (!isSafePropertyKey(key)) {
+              if (this.config?.debug || import.meta.env.DEV) {
+                console.warn('[Analytics] Blocked potentially unsafe property key:', key)
+              }
+              return acc
+            }
+            if (value !== undefined && value !== null) {
+              acc[key] = value
+            }
+            return acc
+          },
+          {} as Record<string, string | number | boolean>
+        )
+      : undefined
+
+    window.fathom.trackGoal(event.name, 0, props)
+  }
+
+  trackWebVitals(vitals: CoreWebVitals): void {
+    if (!this.isEnabled()) {
+      return
+    }
+
+    Object.entries(vitals).forEach(([metric, value]) => {
+      if (value !== undefined) {
+        const formattedValue = metric === 'CLS' ? Number(value.toFixed(3)) : Math.round(value)
+        this.trackEvent({
+          name: 'web_vitals',
+          properties: { metric, value: formattedValue },
+        })
+      }
+    })
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.initialized &&
+      this.scriptLoaded &&
+      typeof window !== 'undefined' &&
+      typeof window.fathom !== 'undefined'
+    )
+  }
+
+  disable(): void {
+    if (this.config?.debug) {
+      console.log('[Analytics] Fathom disabled')
+    }
+
+    this.initialized = false
+    this.scriptLoaded = false
+    this.config = null
+
+    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
+      this.scriptElement.parentNode.removeChild(this.scriptElement)
+      this.scriptElement = null
+    }
+
+    if (typeof window !== 'undefined' && window.fathom) {
+      delete window.fathom
+    }
+  }
+
+  private isDNTEnabled(): boolean {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return false
+    }
+
+    const dnt =
+      navigator.doNotTrack ||
+      (window as Window & { doNotTrack?: string }).doNotTrack ||
+      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
+
+    return dnt === '1' || dnt === 'yes'
+  }
+}

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -152,7 +152,9 @@ export class FathomProvider implements AnalyticsProvider {
       this.initialized &&
       this.scriptLoaded &&
       typeof window !== 'undefined' &&
-      typeof window.fathom !== 'undefined'
+      typeof window.fathom !== 'undefined' &&
+      typeof window.fathom.trackPageview === 'function' &&
+      typeof window.fathom.trackGoal === 'function'
     )
   }
 

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -103,13 +103,23 @@ export class FathomProvider implements AnalyticsProvider {
     }
 
     // Fathom uses provider-assigned goal codes (e.g. "ABCD1234"), not arbitrary strings.
-    // Using event.name as the code will silently drop events unless it matches a real goal ID.
-    // Create matching goals in the Fathom dashboard and pass their codes as event names.
+    // Look up the event name in the configured goalCodes map. If no mapping is found,
+    // skip the event and warn rather than sending an invalid code that Fathom would
+    // silently drop.
+    const goalCode = this.config?.goalCodes?.[event.name]
+    if (!goalCode) {
+      if (this.config?.debug) {
+        console.warn(
+          `[Analytics] Fathom: no goal code mapped for event "${event.name}". ` +
+            `Add an entry to config.goalCodes (e.g. { "${event.name}": "ABCD1234" }) ` +
+            `to enable tracking for this event.`
+        )
+      }
+      return
+    }
+
     if (this.config?.debug) {
-      console.log(
-        `[Analytics] Fathom trackGoal called with code "${event.name}". ` +
-          `Ensure this matches a goal code defined in your Fathom dashboard.`
-      )
+      console.log(`[Analytics] Fathom trackGoal called with code "${goalCode}" for event "${event.name}".`)
     }
 
     const props = event.properties
@@ -130,7 +140,7 @@ export class FathomProvider implements AnalyticsProvider {
         )
       : undefined
 
-    window.fathom.trackGoal(event.name, 0, props)
+    window.fathom.trackGoal(goalCode, 0, props)
   }
 
   trackWebVitals(vitals: CoreWebVitals): void {

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -55,13 +55,30 @@ export class FathomProvider implements AnalyticsProvider {
     }
 
     const defaultUrl = 'https://cdn.usefathom.com/script.js'
-    const configured = this.config?.scriptUrl
-    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
+  private isValidScriptUrl(scriptUrl: string): boolean {
+    try {
+      const parsedUrl = new URL(scriptUrl)
+      return parsedUrl.protocol === 'https:' && parsedUrl.pathname.endsWith('.js')
+    } catch {
+      return false
+    }
+  }
 
-    if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
-      console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
+  private loadScript(): void {
+    if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
+      return
     }
 
+    const defaultScriptUrl = 'https://cdn.usefathom.com/script.js'
+    const configuredScriptUrl = this.config?.scriptUrl
+    const scriptUrl =
+      configuredScriptUrl && this.isValidScriptUrl(configuredScriptUrl)
+        ? configuredScriptUrl
+        : defaultScriptUrl
+
+    if (configuredScriptUrl && scriptUrl !== configuredScriptUrl && this.config?.debug) {
+      console.warn('[Analytics] Invalid Fathom script URL configured, falling back to default script')
+    }
     const script = document.createElement('script')
     script.async = true
     script.defer = true

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -134,6 +134,12 @@ export class FathomProvider implements AnalyticsProvider {
   trackWebVitals(vitals: CoreWebVitals): void {
     // Fathom goal tracking requires provider-assigned goal codes; arbitrary names like
     // 'web_vitals' will be silently dropped. Skip rather than send phantom events.
+    // Guard with isEnabled() for consistency with other providers — avoids work and
+    // log noise when the provider is uninitialised or disabled.
+    if (!this.isEnabled()) {
+      return
+    }
+
     if (this.config?.debug) {
       const available = Object.entries(vitals)
         .filter(([, v]) => v !== undefined)

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -121,7 +121,9 @@ export class FathomProvider implements AnalyticsProvider {
     }
 
     if (this.config?.debug) {
-      console.log(`[Analytics] Fathom trackGoal called with code "${goalCode}" for event "${event.name}".`)
+      console.log(
+        `[Analytics] Fathom trackGoal called with code "${goalCode}" for event "${event.name}".`
+      )
     }
 
     const props = event.properties
@@ -198,5 +200,4 @@ export class FathomProvider implements AnalyticsProvider {
       delete window.fathom
     }
   }
-
 }

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -62,6 +62,15 @@ export class FathomProvider implements AnalyticsProvider {
       console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
     }
 
+    // Fathom has no script attribute to suppress the initial automatic pageview.
+    // Warn in debug/dev so callers know trackPageviews: false cannot be fully honored.
+    if (this.config?.trackPageviews === false && (this.config?.debug || import.meta.env.DEV)) {
+      console.warn(
+        '[Analytics] Fathom does not support disabling automatic pageview tracking via script ' +
+          'attribute. The initial pageview will still be recorded by the Fathom script.'
+      )
+    }
+
     const script = document.createElement('script')
     script.async = true
     script.src = scriptUrl

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -89,7 +89,9 @@ export class FathomProvider implements AnalyticsProvider {
   }
 
   trackPageView(url?: string): void {
-    if (!this.isEnabled() || typeof window === 'undefined' || !window.fathom) {
+    // isEnabled() already verifies window and window.fathom.trackPageview;
+    // re-check the optional chain so TypeScript narrows window.fathom for the call below.
+    if (!this.isEnabled() || !window.fathom?.trackPageview) {
       return
     }
 
@@ -98,7 +100,7 @@ export class FathomProvider implements AnalyticsProvider {
   }
 
   trackEvent(event: AnalyticsEvent): void {
-    if (!this.isEnabled() || typeof window === 'undefined' || !window.fathom) {
+    if (!this.isEnabled() || !window.fathom?.trackGoal) {
       return
     }
 

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -132,19 +132,19 @@ export class FathomProvider implements AnalyticsProvider {
   }
 
   trackWebVitals(vitals: CoreWebVitals): void {
-    if (!this.isEnabled()) {
-      return
-    }
-
-    Object.entries(vitals).forEach(([metric, value]) => {
-      if (value !== undefined) {
-        const formattedValue = metric === 'CLS' ? Number(value.toFixed(3)) : Math.round(value)
-        this.trackEvent({
-          name: 'web_vitals',
-          properties: { metric, value: formattedValue },
-        })
+    // Fathom goal tracking requires provider-assigned goal codes; arbitrary names like
+    // 'web_vitals' will be silently dropped. Skip rather than send phantom events.
+    if (this.config?.debug) {
+      const available = Object.entries(vitals)
+        .filter(([, v]) => v !== undefined)
+        .map(([metric]) => metric)
+      if (available.length > 0) {
+        console.warn(
+          `[Analytics] Fathom does not track Web Vitals without explicit goal-code mapping. ` +
+            `Skipped metrics: ${available.join(', ')}.`
+        )
       }
-    })
+    }
   }
 
   isEnabled(): boolean {

--- a/src/analytics/providers/fathom.ts
+++ b/src/analytics/providers/fathom.ts
@@ -58,7 +58,7 @@ export class FathomProvider implements AnalyticsProvider {
     const configured = this.config?.scriptUrl
     const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
 
-    if (configured && scriptUrl !== configured && this.config?.debug) {
+    if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
       console.warn('[Analytics] Invalid Fathom scriptUrl, falling back to default')
     }
 

--- a/src/analytics/providers/plausible.ts
+++ b/src/analytics/providers/plausible.ts
@@ -60,7 +60,9 @@ export class PlausibleProvider implements AnalyticsProvider {
 
     const scriptUrl = this.config?.scriptUrl || 'https://plausible.io/js/script.js'
 
-    // Validate script URL to prevent injection attacks
+    // Validate script URL to prevent injection attacks.
+    // Uses the shared isValidScriptUrl (HTTPS + .js) rather than a domain whitelist:
+    // the previous whitelist was redundant since it allowed any HTTPS .js URL anyway.
     if (!isValidScriptUrl(scriptUrl)) {
       if (this.config?.debug || import.meta.env.DEV) {
         console.error(

--- a/src/analytics/providers/plausible.ts
+++ b/src/analytics/providers/plausible.ts
@@ -83,6 +83,7 @@ export class PlausibleProvider implements AnalyticsProvider {
     }
 
     script.onerror = () => {
+      if (this.scriptElement !== script) return
       if (this.config?.debug) {
         console.warn('[Analytics] Failed to load Plausible script')
       }
@@ -90,6 +91,7 @@ export class PlausibleProvider implements AnalyticsProvider {
     }
 
     script.onload = () => {
+      if (this.scriptElement !== script) return
       this.scriptLoaded = true
       if (this.config?.debug) {
         console.log('[Analytics] Plausible script loaded successfully')
@@ -218,5 +220,4 @@ export class PlausibleProvider implements AnalyticsProvider {
       delete window.plausible
     }
   }
-
 }

--- a/src/analytics/providers/plausible.ts
+++ b/src/analytics/providers/plausible.ts
@@ -60,9 +60,7 @@ export class PlausibleProvider implements AnalyticsProvider {
 
     const scriptUrl = this.config?.scriptUrl || 'https://plausible.io/js/script.js'
 
-    // Validate script URL to prevent injection attacks.
-    // Uses the shared isValidScriptUrl (HTTPS + .js) rather than a domain whitelist:
-    // the previous whitelist was redundant since it allowed any HTTPS .js URL anyway.
+    // Validate script URL to prevent injection attacks. Requires HTTPS protocol and .js extension.
     if (!isValidScriptUrl(scriptUrl)) {
       if (this.config?.debug || import.meta.env.DEV) {
         console.error(

--- a/src/analytics/providers/plausible.ts
+++ b/src/analytics/providers/plausible.ts
@@ -9,6 +9,7 @@
 
 import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
 import { isSafePropertyKey } from '../../utils/security'
+import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 /**
  * Plausible Analytics provider
@@ -33,7 +34,7 @@ export class PlausibleProvider implements AnalyticsProvider {
     }
 
     // Check if user has Do Not Track enabled
-    if (config.respectDNT !== false && this.isDNTEnabled()) {
+    if (config.respectDNT !== false && isDNTEnabled()) {
       if (config.debug) {
         console.log('[Analytics] Do Not Track is enabled, analytics disabled')
       }
@@ -45,59 +46,6 @@ export class PlausibleProvider implements AnalyticsProvider {
 
     // Load Plausible script asynchronously
     this.loadScript()
-  }
-
-  /**
-   * Validate script URL to prevent script injection attacks
-   * Only allows HTTPS URLs from known analytics providers or valid domains
-   *
-   * @param url - The URL to validate
-   * @returns true if URL is valid and safe, false otherwise
-   */
-  private isValidScriptUrl(url: string): boolean {
-    try {
-      const parsedUrl = new URL(url)
-
-      // Only allow HTTPS for security
-      if (parsedUrl.protocol !== 'https:') {
-        if (this.config?.debug) {
-          console.warn('[Analytics] Script URL must use HTTPS protocol:', url)
-        }
-        return false
-      }
-
-      // Whitelist known analytics providers or allow any HTTPS domain
-      // This prevents obviously malicious URLs while allowing self-hosted instances
-      const knownProviders = [
-        'plausible.io',
-        'analytics.google.com',
-        'fathom.com',
-        'umami.is',
-        'simpleanalytics.com',
-      ]
-
-      const isKnownProvider = knownProviders.some((provider) =>
-        parsedUrl.hostname.endsWith(provider)
-      )
-      const hasValidPath = parsedUrl.pathname.endsWith('.js')
-
-      if (!hasValidPath) {
-        if (this.config?.debug) {
-          console.warn('[Analytics] Script URL must point to a .js file:', url)
-        }
-        return false
-      }
-
-      // Allow known providers or any HTTPS URL pointing to a .js file
-      // (for self-hosted instances)
-      return isKnownProvider || parsedUrl.protocol === 'https:'
-    } catch (error) {
-      // Invalid URL format
-      if (this.config?.debug) {
-        console.warn('[Analytics] Invalid script URL format:', url, error)
-      }
-      return false
-    }
   }
 
   /**
@@ -113,7 +61,7 @@ export class PlausibleProvider implements AnalyticsProvider {
     const scriptUrl = this.config?.scriptUrl || 'https://plausible.io/js/script.js'
 
     // Validate script URL to prevent injection attacks
-    if (!this.isValidScriptUrl(scriptUrl)) {
+    if (!isValidScriptUrl(scriptUrl)) {
       if (this.config?.debug || import.meta.env.DEV) {
         console.error(
           '[Analytics] Invalid or unsafe script URL. Must be HTTPS and point to a .js file:',
@@ -271,20 +219,4 @@ export class PlausibleProvider implements AnalyticsProvider {
     }
   }
 
-  /**
-   * Check if Do Not Track is enabled in browser
-   */
-  private isDNTEnabled(): boolean {
-    // Guard against SSR/Node.js environments
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return false
-    }
-
-    const dnt =
-      navigator.doNotTrack ||
-      (window as Window & { doNotTrack?: string }).doNotTrack ||
-      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
-
-    return dnt === '1' || dnt === 'yes'
-  }
 }

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -32,6 +32,12 @@ describe('analytics/providers/simple', () => {
       configurable: true,
       value: null,
     })
+
+    Object.defineProperty(window, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
   })
 
   afterEach(() => {

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -52,7 +52,6 @@ describe('analytics/providers/simple', () => {
       expect(script).toBeTruthy()
       expect(script.src).toBe('https://scripts.simpleanalyticscdn.com/latest.js')
       expect(script.async).toBe(true)
-      expect(script.defer).toBe(true)
     })
 
     it('should use a valid custom scriptUrl', () => {
@@ -272,10 +271,14 @@ describe('analytics/providers/simple', () => {
     })
 
     it('should block prototype pollution via __proto__', () => {
-      const event: AnalyticsEvent = {
-        name: 'test_event',
-        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
-      }
+      const properties: Record<string, unknown> = { safe: 'ok' }
+      Object.defineProperty(properties, '__proto__', {
+        value: { bad: true },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+      const event: AnalyticsEvent = { name: 'test_event', properties }
       provider.trackEvent(event)
 
       expect(window.sa_event).toHaveBeenCalledWith('test_event', { safe: 'ok' })

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -273,7 +273,7 @@ describe('analytics/providers/simple', () => {
 
     it('should skip and warn when event name normalises to an empty string (debug mode)', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      document.head.innerHTML = ''
+      document.head.replaceChildren()
       const debugProvider = new SimpleAnalyticsProvider()
       debugProvider.init({ ...config, debug: true })
       window.sa_event = vi.fn()

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -211,10 +211,7 @@ describe('analytics/providers/simple', () => {
       delete window.sa_pageview
       // sa_event still present (needed for isEnabled), but sa_pageview missing
 
-      provider.trackPageView('/test')
-
-      // no error thrown
-      expect(true).toBe(true)
+      expect(() => provider.trackPageView('/test')).not.toThrow()
     })
   })
 

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -251,6 +251,12 @@ describe('analytics/providers/simple', () => {
       expect(window.sa_event).toHaveBeenCalledWith('my_event_name', undefined)
     })
 
+    it('should fully normalise event name to snake_case', () => {
+      provider.trackEvent({ name: 'My-Event Name!  Test' })
+
+      expect(window.sa_event).toHaveBeenCalledWith('my_event_name_test', undefined)
+    })
+
     it('should filter out null and undefined properties', () => {
       const event: AnalyticsEvent = {
         name: 'test_event',

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -25,7 +25,7 @@ describe('analytics/providers/simple', () => {
 
     delete window.sa_event
     delete window.sa_pageview
-    document.head.innerHTML = ''
+    document.head.replaceChildren()
 
     Object.defineProperty(navigator, 'doNotTrack', {
       writable: true,

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for Simple Analytics provider
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SimpleAnalyticsProvider } from './simple'
+import type { AnalyticsConfig, AnalyticsEvent, CoreWebVitals } from '../types'
+
+describe('analytics/providers/simple', () => {
+  let provider: SimpleAnalyticsProvider
+  let config: AnalyticsConfig
+
+  beforeEach(() => {
+    provider = new SimpleAnalyticsProvider()
+
+    config = {
+      provider: 'simple',
+      domain: 'example.com',
+      debug: false,
+      trackPageviews: true,
+      trackWebVitals: true,
+      trackScrollDepth: true,
+      respectDNT: true,
+    }
+
+    delete window.sa_event
+    delete window.sa_pageview
+    document.head.innerHTML = ''
+
+    Object.defineProperty(navigator, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('init', () => {
+    it('should inject script with default URL', () => {
+      provider.init(config)
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      expect(script).toBeTruthy()
+      expect(script.src).toBe('https://scripts.simpleanalyticscdn.com/latest.js')
+      expect(script.async).toBe(true)
+      expect(script.defer).toBe(true)
+    })
+
+    it('should use a valid custom scriptUrl', () => {
+      const customConfig = {
+        ...config,
+        scriptUrl: 'https://cdn.example.com/sa-latest.js',
+      }
+      provider.init(customConfig)
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      expect(script.src).toBe('https://cdn.example.com/sa-latest.js')
+    })
+
+    it('should fall back to default URL for non-HTTPS scriptUrl', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.init({ ...config, debug: true, scriptUrl: 'http://insecure.com/sa.js' })
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      expect(script.src).toBe('https://scripts.simpleanalyticscdn.com/latest.js')
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Analytics] Invalid Simple Analytics scriptUrl, falling back to default'
+      )
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should fall back to default URL when scriptUrl has no .js extension', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.init({ ...config, debug: true, scriptUrl: 'https://example.com/tracker' })
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      expect(script.src).toBe('https://scripts.simpleanalyticscdn.com/latest.js')
+      expect(consoleWarnSpy).toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should not initialize twice', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true }
+
+      provider.init(debugConfig)
+      provider.init(debugConfig)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Simple Analytics already initialized')
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should not initialize when Do Not Track is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      provider.init({ ...config, debug: true })
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Analytics] Do Not Track is enabled, analytics disabled'
+      )
+      expect(document.querySelector('script')).toBeNull()
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should ignore DNT when respectDNT is false', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+
+      provider.init({ ...config, respectDNT: false })
+
+      expect(document.querySelector('script')).toBeTruthy()
+    })
+
+    it('should set data-auto-collect="false" when trackPageviews is disabled', () => {
+      provider.init({ ...config, trackPageviews: false })
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      expect(script.getAttribute('data-auto-collect')).toBe('false')
+    })
+
+    it('should handle script load success', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      window.sa_event = vi.fn()
+      script.onload?.(new Event('load'))
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Analytics] Simple Analytics script loaded successfully'
+      )
+      expect(provider.isEnabled()).toBe(true)
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should handle script load error', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onerror?.(new Event('error'))
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Analytics] Failed to load Simple Analytics script'
+      )
+      expect(provider.isEnabled()).toBe(false)
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should detect window.doNotTrack', () => {
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
+
+      provider.init(config)
+      expect(document.querySelector('script')).toBeNull()
+    })
+
+    it('should detect navigator.doNotTrack = "yes"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: 'yes' })
+
+      provider.init(config)
+      expect(document.querySelector('script')).toBeNull()
+    })
+  })
+
+  describe('trackPageView', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+      window.sa_pageview = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track page view with current pathname by default', () => {
+      provider.trackPageView()
+
+      expect(window.sa_pageview).toHaveBeenCalledWith(window.location.pathname)
+    })
+
+    it('should track page view with custom URL', () => {
+      provider.trackPageView('/pricing')
+
+      expect(window.sa_pageview).toHaveBeenCalledWith('/pricing')
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const saPageviewMock = vi.fn()
+      window.sa_pageview = saPageviewMock
+
+      provider.trackPageView()
+
+      expect(saPageviewMock).not.toHaveBeenCalled()
+    })
+
+    it('should not track when sa_pageview is not available', () => {
+      delete window.sa_pageview
+      // sa_event still present (needed for isEnabled), but sa_pageview missing
+
+      provider.trackPageView('/test')
+
+      // no error thrown
+      expect(true).toBe(true)
+    })
+  })
+
+  describe('trackEvent', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+      window.sa_pageview = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should call sa_event with event name and no props', () => {
+      const event: AnalyticsEvent = { name: 'cta_click' }
+      provider.trackEvent(event)
+
+      expect(window.sa_event).toHaveBeenCalledWith('cta_click', undefined)
+    })
+
+    it('should call sa_event with properties', () => {
+      const event: AnalyticsEvent = {
+        name: 'download_click',
+        properties: { platform: 'mac', location: 'hero' },
+      }
+      provider.trackEvent(event)
+
+      expect(window.sa_event).toHaveBeenCalledWith('download_click', {
+        platform: 'mac',
+        location: 'hero',
+      })
+    })
+
+    it('should replace spaces with underscores in event name', () => {
+      provider.trackEvent({ name: 'my event name' })
+
+      expect(window.sa_event).toHaveBeenCalledWith('my_event_name', undefined)
+    })
+
+    it('should filter out null and undefined properties', () => {
+      const event: AnalyticsEvent = {
+        name: 'test_event',
+        properties: {
+          valid: 'value',
+          nullProp: null as unknown as string,
+          undefinedProp: undefined,
+        },
+      }
+      provider.trackEvent(event)
+
+      expect(window.sa_event).toHaveBeenCalledWith('test_event', { valid: 'value' })
+    })
+
+    it('should block prototype pollution via __proto__', () => {
+      const event: AnalyticsEvent = {
+        name: 'test_event',
+        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
+      }
+      provider.trackEvent(event)
+
+      expect(window.sa_event).toHaveBeenCalledWith('test_event', { safe: 'ok' })
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const saEventMock = vi.fn()
+      window.sa_event = saEventMock
+
+      provider.trackEvent({ name: 'test_event' })
+
+      expect(saEventMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trackWebVitals', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+      window.sa_pageview = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track each defined Core Web Vitals metric', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, CLS: 0.12345 }
+      provider.trackWebVitals(vitals)
+
+      expect(window.sa_event).toHaveBeenCalledTimes(2)
+      expect(window.sa_event).toHaveBeenCalledWith('web_vitals', { metric: 'LCP', value: 2500 })
+      expect(window.sa_event).toHaveBeenCalledWith('web_vitals', { metric: 'CLS', value: 0.123 })
+    })
+
+    it('should skip undefined metrics', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, FID: undefined }
+      provider.trackWebVitals(vitals)
+
+      expect(window.sa_event).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const saEventMock = vi.fn()
+      window.sa_event = saEventMock
+
+      provider.trackWebVitals({ LCP: 2500 })
+
+      expect(saEventMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isEnabled', () => {
+    it('should return false when not initialized', () => {
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return false when script not yet loaded', () => {
+      provider.init(config)
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return true when initialized and script loaded', () => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      expect(provider.isEnabled()).toBe(true)
+    })
+
+    it('should return false after disable', () => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(provider.isEnabled()).toBe(false)
+    })
+  })
+
+  describe('disable', () => {
+    it('should reset state and remove script', () => {
+      provider.init(config)
+      expect(document.querySelector('script')).toBeTruthy()
+
+      provider.disable()
+
+      expect(document.querySelector('script')).toBeNull()
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should delete window.sa_event and window.sa_pageview', () => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+      window.sa_pageview = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(window.sa_event).toBeUndefined()
+      expect(window.sa_pageview).toBeUndefined()
+    })
+
+    it('should log debug message when debug is enabled', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugProvider = new SimpleAnalyticsProvider()
+      debugProvider.init({ ...config, debug: true })
+
+      debugProvider.disable()
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Simple Analytics disabled')
+      consoleLogSpy.mockRestore()
+    })
+  })
+})

--- a/src/analytics/providers/simple.test.ts
+++ b/src/analytics/providers/simple.test.ts
@@ -172,6 +172,21 @@ describe('analytics/providers/simple', () => {
       provider.init(config)
       expect(document.querySelector('script')).toBeNull()
     })
+
+    it('should not inject a second script when loadScript is called while already loaded', () => {
+      provider.init(config)
+      window.sa_event = vi.fn()
+      window.sa_pageview = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      // scriptLoaded is now true; manually trigger loadScript via the internal state path
+      ;(provider as unknown as { loadScript: () => void }).loadScript()
+
+      // Only one script should be in the DOM
+      expect(document.querySelectorAll('script').length).toBe(1)
+    })
   })
 
   describe('trackPageView', () => {
@@ -254,6 +269,26 @@ describe('analytics/providers/simple', () => {
       provider.trackEvent({ name: 'My-Event Name!  Test' })
 
       expect(window.sa_event).toHaveBeenCalledWith('my_event_name_test', undefined)
+    })
+
+    it('should skip and warn when event name normalises to an empty string (debug mode)', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      document.head.innerHTML = ''
+      const debugProvider = new SimpleAnalyticsProvider()
+      debugProvider.init({ ...config, debug: true })
+      window.sa_event = vi.fn()
+
+      const script = document.querySelector('script') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      // '---' normalises to '' after all replacements, triggering the empty-name guard
+      debugProvider.trackEvent({ name: '---' })
+
+      expect(window.sa_event).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('normalises to an empty string')
+      )
+      consoleWarnSpy.mockRestore()
     })
 
     it('should filter out null and undefined properties', () => {

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -10,6 +10,7 @@
 
 import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
 import { isSafePropertyKey } from '../../utils/security'
+import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 /**
  * Simple Analytics provider
@@ -29,7 +30,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
       return
     }
 
-    if (config.respectDNT !== false && this.isDNTEnabled()) {
+    if (config.respectDNT !== false && isDNTEnabled()) {
       if (config.debug) {
         console.log('[Analytics] Do Not Track is enabled, analytics disabled')
       }
@@ -41,15 +42,6 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     this.loadScript()
   }
 
-  private isValidScriptUrl(url: string): boolean {
-    try {
-      const parsed = new URL(url)
-      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
-    } catch {
-      return false
-    }
-  }
-
   private loadScript(): void {
     if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
       return
@@ -57,7 +49,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
 
     const defaultUrl = 'https://scripts.simpleanalyticscdn.com/latest.js'
     const configured = this.config?.scriptUrl
-    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
+    const scriptUrl = configured && isValidScriptUrl(configured) ? configured : defaultUrl
 
     if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
       console.warn('[Analytics] Invalid Simple Analytics scriptUrl, falling back to default')
@@ -182,18 +174,5 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
       if (window.sa_event) delete window.sa_event
       if (window.sa_pageview) delete window.sa_pageview
     }
-  }
-
-  private isDNTEnabled(): boolean {
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return false
-    }
-
-    const dnt =
-      navigator.doNotTrack ||
-      (window as Window & { doNotTrack?: string }).doNotTrack ||
-      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
-
-    return dnt === '1' || dnt === 'yes'
   }
 }

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -64,7 +64,6 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
 
     const script = document.createElement('script')
     script.async = true
-    script.defer = true
     script.src = scriptUrl
 
     // Simple Analytics detects the domain automatically; no data attribute needed.

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -1,0 +1,173 @@
+/**
+ * Simple Analytics provider implementation
+ *
+ * Privacy-friendly, no-cookie analytics with a clean dashboard.
+ * Page views are tracked automatically by the script.
+ *
+ * @see https://docs.simpleanalytics.com
+ */
+
+import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
+import { isSafePropertyKey } from '../../utils/security'
+
+/**
+ * Simple Analytics provider
+ * Implements cookie-less analytics tracking via the Simple Analytics script API
+ */
+export class SimpleAnalyticsProvider implements AnalyticsProvider {
+  private config: AnalyticsConfig | null = null
+  private initialized = false
+  private scriptLoaded = false
+  private scriptElement: HTMLScriptElement | null = null
+
+  init(config: AnalyticsConfig): void {
+    if (this.initialized) {
+      if (config.debug) {
+        console.log('[Analytics] Simple Analytics already initialized')
+      }
+      return
+    }
+
+    if (config.respectDNT !== false && this.isDNTEnabled()) {
+      if (config.debug) {
+        console.log('[Analytics] Do Not Track is enabled, analytics disabled')
+      }
+      return
+    }
+
+    this.config = config
+    this.initialized = true
+    this.loadScript()
+  }
+
+  private loadScript(): void {
+    if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const scriptUrl =
+      this.config?.scriptUrl || 'https://scripts.simpleanalyticscdn.com/latest.js'
+
+    const script = document.createElement('script')
+    script.async = true
+    script.defer = true
+    script.src = scriptUrl
+
+    // Simple Analytics detects the domain automatically; no data attribute needed.
+    if (this.config?.trackPageviews === false) {
+      script.setAttribute('data-auto-collect', 'false')
+    }
+
+    script.onerror = () => {
+      if (this.config?.debug) {
+        console.warn('[Analytics] Failed to load Simple Analytics script')
+      }
+      this.scriptLoaded = false
+    }
+
+    script.onload = () => {
+      this.scriptLoaded = true
+      if (this.config?.debug) {
+        console.log('[Analytics] Simple Analytics script loaded successfully')
+      }
+    }
+
+    this.scriptElement = script
+    document.head.appendChild(script)
+  }
+
+  trackPageView(url?: string): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.sa_pageview) {
+      return
+    }
+
+    const pageUrl = url || window.location.pathname
+    window.sa_pageview(pageUrl)
+  }
+
+  trackEvent(event: AnalyticsEvent): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.sa_event) {
+      return
+    }
+
+    const props = event.properties
+      ? Object.entries(event.properties).reduce(
+          (acc, [key, value]) => {
+            if (!isSafePropertyKey(key)) {
+              if (this.config?.debug || import.meta.env.DEV) {
+                console.warn('[Analytics] Blocked potentially unsafe property key:', key)
+              }
+              return acc
+            }
+            if (value !== undefined && value !== null) {
+              acc[key] = value
+            }
+            return acc
+          },
+          {} as Record<string, string | number | boolean>
+        )
+      : undefined
+
+    // Simple Analytics event names must be snake_case; replace any spaces with underscores
+    const safeName = event.name.replace(/\s+/g, '_')
+    window.sa_event(safeName, props)
+  }
+
+  trackWebVitals(vitals: CoreWebVitals): void {
+    if (!this.isEnabled()) {
+      return
+    }
+
+    Object.entries(vitals).forEach(([metric, value]) => {
+      if (value !== undefined) {
+        const formattedValue = metric === 'CLS' ? Number(value.toFixed(3)) : Math.round(value)
+        this.trackEvent({
+          name: 'web_vitals',
+          properties: { metric, value: formattedValue },
+        })
+      }
+    })
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.initialized &&
+      this.scriptLoaded &&
+      typeof window !== 'undefined' &&
+      typeof window.sa_event === 'function'
+    )
+  }
+
+  disable(): void {
+    if (this.config?.debug) {
+      console.log('[Analytics] Simple Analytics disabled')
+    }
+
+    this.initialized = false
+    this.scriptLoaded = false
+    this.config = null
+
+    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
+      this.scriptElement.parentNode.removeChild(this.scriptElement)
+      this.scriptElement = null
+    }
+
+    if (typeof window !== 'undefined') {
+      if (window.sa_event) delete window.sa_event
+      if (window.sa_pageview) delete window.sa_pageview
+    }
+  }
+
+  private isDNTEnabled(): boolean {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return false
+    }
+
+    const dnt =
+      navigator.doNotTrack ||
+      (window as Window & { doNotTrack?: string }).doNotTrack ||
+      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
+
+    return dnt === '1' || dnt === 'yes'
+  }
+}

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -2,7 +2,8 @@
  * Simple Analytics provider implementation
  *
  * Privacy-friendly, no-cookie analytics with a clean dashboard.
- * Page views are tracked automatically by the script.
+ * The script tracks the initial page load automatically.
+ * For SPA navigations, call `sa_pageview` manually via `trackPageView()`.
  *
  * @see https://docs.simpleanalytics.com
  */

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -122,7 +122,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
         )
       : undefined
 
-    // Simple Analytics event names must be snake_case; replace any spaces with underscores
+    // Simple Analytics recommends snake_case event names; spaces are replaced with underscores
     const safeName = event.name.replace(/\s+/g, '_')
     window.sa_event(safeName, props)
   }

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -73,6 +73,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     }
 
     script.onerror = () => {
+      if (this.scriptElement !== script) return
       if (this.config?.debug) {
         console.warn('[Analytics] Failed to load Simple Analytics script')
       }
@@ -80,6 +81,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     }
 
     script.onload = () => {
+      if (this.scriptElement !== script) return
       this.scriptLoaded = true
       if (this.config?.debug) {
         console.log('[Analytics] Simple Analytics script loaded successfully')

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -171,8 +171,10 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     this.scriptLoaded = false
     this.config = null
 
-    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
-      this.scriptElement.parentNode.removeChild(this.scriptElement)
+    if (typeof document !== 'undefined' && this.scriptElement) {
+      if (this.scriptElement.parentNode) {
+        this.scriptElement.parentNode.removeChild(this.scriptElement)
+      }
       this.scriptElement = null
     }
 

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -58,7 +58,7 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     const configured = this.config?.scriptUrl
     const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
 
-    if (configured && scriptUrl !== configured && this.config?.debug) {
+    if (configured && scriptUrl !== configured && (this.config?.debug || import.meta.env.DEV)) {
       console.warn('[Analytics] Invalid Simple Analytics scriptUrl, falling back to default')
     }
 

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -122,9 +122,17 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
         )
       : undefined
 
-    // Simple Analytics recommends snake_case event names; spaces are replaced with underscores
-    const safeName = event.name.replace(/\s+/g, '_')
+    // Normalise to snake_case: lowercase, replace non-alphanumeric with underscores, collapse/trim
+    const safeName = this.normalizeEventName(event.name)
     window.sa_event(safeName, props)
+  }
+
+  private normalizeEventName(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^_+|_+$/g, '')
   }
 
   trackWebVitals(vitals: CoreWebVitals): void {

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -40,13 +40,27 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
     this.loadScript()
   }
 
+  private isValidScriptUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
+    } catch {
+      return false
+    }
+  }
+
   private loadScript(): void {
     if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
       return
     }
 
-    const scriptUrl =
-      this.config?.scriptUrl || 'https://scripts.simpleanalyticscdn.com/latest.js'
+    const defaultUrl = 'https://scripts.simpleanalyticscdn.com/latest.js'
+    const configured = this.config?.scriptUrl
+    const scriptUrl = configured && this.isValidScriptUrl(configured) ? configured : defaultUrl
+
+    if (configured && scriptUrl !== configured && this.config?.debug) {
+      console.warn('[Analytics] Invalid Simple Analytics scriptUrl, falling back to default')
+    }
 
     const script = document.createElement('script')
     script.async = true

--- a/src/analytics/providers/simple.ts
+++ b/src/analytics/providers/simple.ts
@@ -118,6 +118,14 @@ export class SimpleAnalyticsProvider implements AnalyticsProvider {
 
     // Normalise to snake_case: lowercase, replace non-alphanumeric with underscores, collapse/trim
     const safeName = this.normalizeEventName(event.name)
+    if (!safeName) {
+      if (this.config?.debug || import.meta.env.DEV) {
+        console.warn(
+          `[Analytics] Simple Analytics: event name "${event.name}" normalises to an empty string; skipping.`
+        )
+      }
+      return
+    }
     window.sa_event(safeName, props)
   }
 

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -12,7 +12,9 @@ describe('analytics/providers/umami', () => {
 
   const SCRIPT_URL = 'https://analytics.example.com/umami.js'
 
-  const mockUmami = () => ({
+  type UmamiMock = { track: ReturnType<typeof vi.fn>; identify: ReturnType<typeof vi.fn> }
+
+  const mockUmami = (): UmamiMock => ({
     track: vi.fn(),
     identify: vi.fn(),
   })
@@ -32,7 +34,7 @@ describe('analytics/providers/umami', () => {
     }
 
     delete window.umami
-    document.head.innerHTML = ''
+    document.head.replaceChildren()
 
     Object.defineProperty(navigator, 'doNotTrack', {
       writable: true,

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -60,7 +60,6 @@ describe('analytics/providers/umami', () => {
       expect(script.src).toBe(SCRIPT_URL)
       expect(script.getAttribute('data-website-id')).toBe('my-website-id-uuid')
       expect(script.async).toBe(true)
-      expect(script.defer).toBe(true)
     })
 
     it('should warn and not init when scriptUrl is missing', () => {
@@ -200,13 +199,21 @@ describe('analytics/providers/umami', () => {
     it('should track page view with current pathname by default', () => {
       provider.trackPageView()
 
-      expect(window.umami!.track).toHaveBeenCalledWith({ url: window.location.pathname })
+      expect(window.umami!.track).toHaveBeenCalledWith(expect.any(Function))
+      const callback = vi.mocked(window.umami!.track).mock.calls[0][0] as (
+        p: Record<string, unknown>
+      ) => Record<string, unknown>
+      expect(callback({ title: 'Home' })).toEqual({ title: 'Home', url: window.location.pathname })
     })
 
     it('should track page view with custom URL', () => {
       provider.trackPageView('/features')
 
-      expect(window.umami!.track).toHaveBeenCalledWith({ url: '/features' })
+      expect(window.umami!.track).toHaveBeenCalledWith(expect.any(Function))
+      const callback = vi.mocked(window.umami!.track).mock.calls[0][0] as (
+        p: Record<string, unknown>
+      ) => Record<string, unknown>
+      expect(callback({ title: 'Features' })).toEqual({ title: 'Features', url: '/features' })
     })
 
     it('should not track when provider is not enabled', () => {

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -39,6 +39,12 @@ describe('analytics/providers/umami', () => {
       configurable: true,
       value: null,
     })
+
+    Object.defineProperty(window, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
   })
 
   afterEach(() => {

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for Umami Analytics provider
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { UmamiProvider } from './umami'
+import type { AnalyticsConfig, AnalyticsEvent, CoreWebVitals } from '../types'
+
+describe('analytics/providers/umami', () => {
+  let provider: UmamiProvider
+  let config: AnalyticsConfig
+
+  const SCRIPT_URL = 'https://analytics.example.com/umami.js'
+
+  const mockUmami = () => ({
+    track: vi.fn(),
+    identify: vi.fn(),
+  })
+
+  beforeEach(() => {
+    provider = new UmamiProvider()
+
+    config = {
+      provider: 'umami',
+      domain: 'my-website-id-uuid',
+      scriptUrl: SCRIPT_URL,
+      debug: false,
+      trackPageviews: true,
+      trackWebVitals: true,
+      trackScrollDepth: true,
+      respectDNT: true,
+    }
+
+    delete window.umami
+    document.head.innerHTML = ''
+
+    Object.defineProperty(navigator, 'doNotTrack', {
+      writable: true,
+      configurable: true,
+      value: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('init', () => {
+    it('should inject script with data-website-id attribute', () => {
+      provider.init(config)
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      expect(script).toBeTruthy()
+      expect(script.src).toBe(SCRIPT_URL)
+      expect(script.getAttribute('data-website-id')).toBe('my-website-id-uuid')
+      expect(script.async).toBe(true)
+      expect(script.defer).toBe(true)
+    })
+
+    it('should warn and not init when scriptUrl is missing', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.stubEnv('DEV', true)
+
+      provider.init({ ...config, scriptUrl: undefined })
+
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('requires a scriptUrl'))
+
+      consoleWarnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    })
+
+    it('should warn and not init when scriptUrl is non-HTTPS', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.stubEnv('DEV', true)
+
+      provider.init({ ...config, scriptUrl: 'http://insecure.com/umami.js' })
+
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('must be HTTPS'),
+        'http://insecure.com/umami.js'
+      )
+
+      consoleWarnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    })
+
+    it('should warn and not init when scriptUrl has no .js extension', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.stubEnv('DEV', true)
+
+      provider.init({ ...config, scriptUrl: 'https://example.com/tracker' })
+
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+      expect(consoleWarnSpy).toHaveBeenCalled()
+
+      consoleWarnSpy.mockRestore()
+      vi.unstubAllEnvs()
+    })
+
+    it('should not initialize twice', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugConfig = { ...config, debug: true }
+
+      provider.init(debugConfig)
+      provider.init(debugConfig)
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Umami already initialized')
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should not initialize when Do Not Track is enabled', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      provider.init({ ...config, debug: true })
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Analytics] Do Not Track is enabled, analytics disabled'
+      )
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should ignore DNT when respectDNT is false', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+
+      provider.init({ ...config, respectDNT: false })
+
+      expect(document.querySelector('script[data-website-id]')).toBeTruthy()
+    })
+
+    it('should set data-auto-track="false" when trackPageviews is disabled', () => {
+      provider.init({ ...config, trackPageviews: false })
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      expect(script.getAttribute('data-auto-track')).toBe('false')
+    })
+
+    it('should handle script load success', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      window.umami = mockUmami()
+      script.onload?.(new Event('load'))
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Umami script loaded successfully')
+      expect(provider.isEnabled()).toBe(true)
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should handle script load error', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      provider.init({ ...config, debug: true })
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onerror?.(new Event('error'))
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[Analytics] Failed to load Umami script')
+      expect(provider.isEnabled()).toBe(false)
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should detect window.doNotTrack', () => {
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
+
+      provider.init(config)
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+    })
+
+    it('should detect navigator.doNotTrack = "yes"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: 'yes' })
+
+      provider.init(config)
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+    })
+  })
+
+  describe('trackPageView', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track page view with current pathname by default', () => {
+      provider.trackPageView()
+
+      expect(window.umami!.track).toHaveBeenCalledWith({ url: window.location.pathname })
+    })
+
+    it('should track page view with custom URL', () => {
+      provider.trackPageView('/features')
+
+      expect(window.umami!.track).toHaveBeenCalledWith({ url: '/features' })
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const umamiMock = mockUmami()
+      window.umami = umamiMock
+
+      provider.trackPageView()
+
+      expect(umamiMock.track).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trackEvent', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should call umami.track with event name and no props', () => {
+      const event: AnalyticsEvent = { name: 'cta_click' }
+      provider.trackEvent(event)
+
+      expect(window.umami!.track).toHaveBeenCalledWith('cta_click', undefined)
+    })
+
+    it('should call umami.track with event name and properties', () => {
+      const event: AnalyticsEvent = {
+        name: 'download_click',
+        properties: { platform: 'mac', location: 'hero' },
+      }
+      provider.trackEvent(event)
+
+      expect(window.umami!.track).toHaveBeenCalledWith('download_click', {
+        platform: 'mac',
+        location: 'hero',
+      })
+    })
+
+    it('should filter out null and undefined properties', () => {
+      const event: AnalyticsEvent = {
+        name: 'test_event',
+        properties: {
+          valid: 'value',
+          nullProp: null as unknown as string,
+          undefinedProp: undefined,
+        },
+      }
+      provider.trackEvent(event)
+
+      expect(window.umami!.track).toHaveBeenCalledWith('test_event', { valid: 'value' })
+    })
+
+    it('should block prototype pollution via __proto__', () => {
+      const event: AnalyticsEvent = {
+        name: 'test_event',
+        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
+      }
+      provider.trackEvent(event)
+
+      expect(window.umami!.track).toHaveBeenCalledWith('test_event', { safe: 'ok' })
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const umamiMock = mockUmami()
+      window.umami = umamiMock
+
+      provider.trackEvent({ name: 'test_event' })
+
+      expect(umamiMock.track).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trackWebVitals', () => {
+    beforeEach(() => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+    })
+
+    it('should track each defined Core Web Vitals metric', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, CLS: 0.12345 }
+      provider.trackWebVitals(vitals)
+
+      expect(window.umami!.track).toHaveBeenCalledTimes(2)
+      expect(window.umami!.track).toHaveBeenCalledWith('web_vitals', {
+        metric: 'LCP',
+        value: 2500,
+      })
+      expect(window.umami!.track).toHaveBeenCalledWith('web_vitals', {
+        metric: 'CLS',
+        value: 0.123,
+      })
+    })
+
+    it('should skip undefined metrics', () => {
+      const vitals: CoreWebVitals = { LCP: 2500, FID: undefined }
+      provider.trackWebVitals(vitals)
+
+      expect(window.umami!.track).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not track when provider is not enabled', () => {
+      provider.disable()
+      const umamiMock = mockUmami()
+      window.umami = umamiMock
+
+      provider.trackWebVitals({ LCP: 2500 })
+
+      expect(umamiMock.track).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isEnabled', () => {
+    it('should return false when not initialized', () => {
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return false when script not yet loaded', () => {
+      provider.init(config)
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should return true when initialized and script loaded', () => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      expect(provider.isEnabled()).toBe(true)
+    })
+
+    it('should return false after disable', () => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(provider.isEnabled()).toBe(false)
+    })
+  })
+
+  describe('disable', () => {
+    it('should reset state and remove script', () => {
+      provider.init(config)
+      expect(document.querySelector('script[data-website-id]')).toBeTruthy()
+
+      provider.disable()
+
+      expect(document.querySelector('script[data-website-id]')).toBeNull()
+      expect(provider.isEnabled()).toBe(false)
+    })
+
+    it('should delete window.umami', () => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      provider.disable()
+
+      expect(window.umami).toBeUndefined()
+    })
+
+    it('should log debug message when debug is enabled', () => {
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const debugProvider = new UmamiProvider()
+      debugProvider.init({ ...config, debug: true })
+
+      debugProvider.disable()
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('[Analytics] Umami disabled')
+      consoleLogSpy.mockRestore()
+    })
+  })
+})

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -185,6 +185,20 @@ describe('analytics/providers/umami', () => {
       provider.init(config)
       expect(document.querySelector('script[data-website-id]')).toBeNull()
     })
+
+    it('should not inject a second script when loadScript is called while already loaded', () => {
+      provider.init(config)
+      window.umami = mockUmami()
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      // scriptLoaded is now true; manually trigger loadScript via the internal state path
+      ;(provider as unknown as { loadScript: () => void }).loadScript()
+
+      // Only one script should be in the DOM
+      expect(document.querySelectorAll('script[data-website-id]').length).toBe(1)
+    })
   })
 
   describe('trackPageView', () => {

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -49,6 +49,7 @@ describe('analytics/providers/umami', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
   })
 
   describe('init', () => {

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -271,10 +271,14 @@ describe('analytics/providers/umami', () => {
     })
 
     it('should block prototype pollution via __proto__', () => {
-      const event: AnalyticsEvent = {
-        name: 'test_event',
-        properties: { safe: 'ok', __proto__: { bad: true } } as Record<string, unknown>,
-      }
+      const properties: Record<string, unknown> = { safe: 'ok' }
+      Object.defineProperty(properties, '__proto__', {
+        value: { bad: true },
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      })
+      const event: AnalyticsEvent = { name: 'test_event', properties }
       provider.trackEvent(event)
 
       expect(window.umami!.track).toHaveBeenCalledWith('test_event', { safe: 'ok' })

--- a/src/analytics/providers/umami.test.ts
+++ b/src/analytics/providers/umami.test.ts
@@ -364,6 +364,16 @@ describe('analytics/providers/umami', () => {
 
       expect(provider.isEnabled()).toBe(false)
     })
+
+    it('should return false when window.umami exists but track is not a function', () => {
+      provider.init(config)
+      window.umami = { track: 'not-a-function' } as unknown as typeof window.umami
+
+      const script = document.querySelector('script[data-website-id]') as HTMLScriptElement
+      script.onload?.(new Event('load'))
+
+      expect(provider.isEnabled()).toBe(false)
+    })
   })
 
   describe('disable', () => {

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -86,6 +86,7 @@ export class UmamiProvider implements AnalyticsProvider {
     }
 
     script.onerror = () => {
+      if (this.scriptElement !== script) return
       if (this.config?.debug) {
         console.warn('[Analytics] Failed to load Umami script')
       }
@@ -93,6 +94,7 @@ export class UmamiProvider implements AnalyticsProvider {
     }
 
     script.onload = () => {
+      if (this.scriptElement !== script) return
       this.scriptLoaded = true
       if (this.config?.debug) {
         console.log('[Analytics] Umami script loaded successfully')

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -178,5 +178,4 @@ export class UmamiProvider implements AnalyticsProvider {
       delete window.umami
     }
   }
-
 }

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -75,12 +75,13 @@ export class UmamiProvider implements AnalyticsProvider {
 
     const script = document.createElement('script')
     script.async = true
-    script.defer = true
     script.src = scriptUrl
     // Umami uses data-website-id for the site identifier
     script.setAttribute('data-website-id', this.config?.domain || '')
 
     if (this.config?.trackPageviews === false) {
+      // data-auto-track="false" disables ALL automatic tracking (pageviews and events),
+      // not just pageviews. Manual umami.track(...) calls continue to work.
       script.setAttribute('data-auto-track', 'false')
     }
 
@@ -108,7 +109,7 @@ export class UmamiProvider implements AnalyticsProvider {
     }
 
     const pageUrl = url || window.location.pathname
-    window.umami.track({ url: pageUrl })
+    window.umami.track((props: Record<string, unknown>) => ({ ...props, url: pageUrl }))
   }
 
   trackEvent(event: AnalyticsEvent): void {

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -175,8 +175,10 @@ export class UmamiProvider implements AnalyticsProvider {
     this.scriptLoaded = false
     this.config = null
 
-    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
-      this.scriptElement.parentNode.removeChild(this.scriptElement)
+    if (typeof document !== 'undefined' && this.scriptElement) {
+      if (this.scriptElement.parentNode) {
+        this.scriptElement.parentNode.removeChild(this.scriptElement)
+      }
       this.scriptElement = null
     }
 

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -9,6 +9,7 @@
 
 import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
 import { isSafePropertyKey } from '../../utils/security'
+import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 /**
  * Umami Analytics provider
@@ -25,7 +26,7 @@ export class UmamiProvider implements AnalyticsProvider {
       if (config.debug) console.log('[Analytics] Umami already initialized')
       return
     }
-    if (config.respectDNT !== false && this.isDNTEnabled()) {
+    if (config.respectDNT !== false && isDNTEnabled()) {
       if (config.debug) console.log('[Analytics] Do Not Track is enabled, analytics disabled')
       return
     }
@@ -48,22 +49,13 @@ export class UmamiProvider implements AnalyticsProvider {
       }
       return null
     }
-    if (!this.isValidScriptUrl(url)) {
+    if (!isValidScriptUrl(url)) {
       if (config.debug || import.meta.env.DEV) {
         console.warn('[Analytics] Umami scriptUrl must be HTTPS and point to a .js file:', url)
       }
       return null
     }
     return url
-  }
-
-  private isValidScriptUrl(url: string): boolean {
-    try {
-      const parsed = new URL(url)
-      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
-    } catch {
-      return false
-    }
   }
 
   private loadScript(): void {
@@ -187,16 +179,4 @@ export class UmamiProvider implements AnalyticsProvider {
     }
   }
 
-  private isDNTEnabled(): boolean {
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return false
-    }
-
-    const dnt =
-      navigator.doNotTrack ||
-      (window as Window & { doNotTrack?: string }).doNotTrack ||
-      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
-
-    return dnt === '1' || dnt === 'yes'
-  }
 }

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -22,32 +22,48 @@ export class UmamiProvider implements AnalyticsProvider {
 
   init(config: AnalyticsConfig): void {
     if (this.initialized) {
-      if (config.debug) {
-        console.log('[Analytics] Umami already initialized')
-      }
+      if (config.debug) console.log('[Analytics] Umami already initialized')
       return
     }
-
     if (config.respectDNT !== false && this.isDNTEnabled()) {
-      if (config.debug) {
-        console.log('[Analytics] Do Not Track is enabled, analytics disabled')
-      }
+      if (config.debug) console.log('[Analytics] Do Not Track is enabled, analytics disabled')
       return
     }
+    if (!this.resolveScriptUrl(config)) {
+      return
+    }
+    this.config = config
+    this.initialized = true
+    this.loadScript()
+  }
 
-    if (!config.scriptUrl) {
+  private resolveScriptUrl(config: AnalyticsConfig): string | null {
+    const url = config.scriptUrl
+    if (!url) {
       if (config.debug || import.meta.env.DEV) {
         console.warn(
           '[Analytics] Umami requires a scriptUrl (your self-hosted or cloud instance script URL). ' +
             'Set VITE_ANALYTICS_SCRIPT_URL in your environment.'
         )
       }
-      return
+      return null
     }
+    if (!this.isValidScriptUrl(url)) {
+      if (config.debug || import.meta.env.DEV) {
+        console.warn('[Analytics] Umami scriptUrl must be HTTPS and point to a .js file:', url)
+      }
+      return null
+    }
+    return url
+  }
 
-    this.config = config
-    this.initialized = true
-    this.loadScript()
+  private isValidScriptUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url)
+      return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
+    } catch {
+      return false
+    }
   }
 
   private loadScript(): void {

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -159,7 +159,8 @@ export class UmamiProvider implements AnalyticsProvider {
       this.initialized &&
       this.scriptLoaded &&
       typeof window !== 'undefined' &&
-      typeof window.umami !== 'undefined'
+      typeof window.umami !== 'undefined' &&
+      typeof window.umami.track === 'function'
     )
   }
 

--- a/src/analytics/providers/umami.ts
+++ b/src/analytics/providers/umami.ts
@@ -1,0 +1,180 @@
+/**
+ * Umami Analytics provider implementation
+ *
+ * Open-source, self-hostable, privacy-focused analytics.
+ * Requires a self-hosted or cloud Umami instance and a custom scriptUrl.
+ *
+ * @see https://umami.is/docs
+ */
+
+import type { AnalyticsConfig, AnalyticsEvent, AnalyticsProvider, CoreWebVitals } from '../types'
+import { isSafePropertyKey } from '../../utils/security'
+
+/**
+ * Umami Analytics provider
+ * Implements cookie-less analytics tracking via the Umami script API
+ */
+export class UmamiProvider implements AnalyticsProvider {
+  private config: AnalyticsConfig | null = null
+  private initialized = false
+  private scriptLoaded = false
+  private scriptElement: HTMLScriptElement | null = null
+
+  init(config: AnalyticsConfig): void {
+    if (this.initialized) {
+      if (config.debug) {
+        console.log('[Analytics] Umami already initialized')
+      }
+      return
+    }
+
+    if (config.respectDNT !== false && this.isDNTEnabled()) {
+      if (config.debug) {
+        console.log('[Analytics] Do Not Track is enabled, analytics disabled')
+      }
+      return
+    }
+
+    if (!config.scriptUrl) {
+      if (config.debug || import.meta.env.DEV) {
+        console.warn(
+          '[Analytics] Umami requires a scriptUrl (your self-hosted or cloud instance script URL). ' +
+            'Set VITE_ANALYTICS_SCRIPT_URL in your environment.'
+        )
+      }
+      return
+    }
+
+    this.config = config
+    this.initialized = true
+    this.loadScript()
+  }
+
+  private loadScript(): void {
+    if (this.scriptLoaded || typeof window === 'undefined' || typeof document === 'undefined') {
+      return
+    }
+
+    const scriptUrl = this.config!.scriptUrl!
+
+    const script = document.createElement('script')
+    script.async = true
+    script.defer = true
+    script.src = scriptUrl
+    // Umami uses data-website-id for the site identifier
+    script.setAttribute('data-website-id', this.config?.domain || '')
+
+    if (this.config?.trackPageviews === false) {
+      script.setAttribute('data-auto-track', 'false')
+    }
+
+    script.onerror = () => {
+      if (this.config?.debug) {
+        console.warn('[Analytics] Failed to load Umami script')
+      }
+      this.scriptLoaded = false
+    }
+
+    script.onload = () => {
+      this.scriptLoaded = true
+      if (this.config?.debug) {
+        console.log('[Analytics] Umami script loaded successfully')
+      }
+    }
+
+    this.scriptElement = script
+    document.head.appendChild(script)
+  }
+
+  trackPageView(url?: string): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.umami) {
+      return
+    }
+
+    const pageUrl = url || window.location.pathname
+    window.umami.track({ url: pageUrl })
+  }
+
+  trackEvent(event: AnalyticsEvent): void {
+    if (!this.isEnabled() || typeof window === 'undefined' || !window.umami) {
+      return
+    }
+
+    const props = event.properties
+      ? Object.entries(event.properties).reduce(
+          (acc, [key, value]) => {
+            if (!isSafePropertyKey(key)) {
+              if (this.config?.debug || import.meta.env.DEV) {
+                console.warn('[Analytics] Blocked potentially unsafe property key:', key)
+              }
+              return acc
+            }
+            if (value !== undefined && value !== null) {
+              acc[key] = value
+            }
+            return acc
+          },
+          {} as Record<string, string | number | boolean>
+        )
+      : undefined
+
+    window.umami.track(event.name, props)
+  }
+
+  trackWebVitals(vitals: CoreWebVitals): void {
+    if (!this.isEnabled()) {
+      return
+    }
+
+    Object.entries(vitals).forEach(([metric, value]) => {
+      if (value !== undefined) {
+        const formattedValue = metric === 'CLS' ? Number(value.toFixed(3)) : Math.round(value)
+        this.trackEvent({
+          name: 'web_vitals',
+          properties: { metric, value: formattedValue },
+        })
+      }
+    })
+  }
+
+  isEnabled(): boolean {
+    return (
+      this.initialized &&
+      this.scriptLoaded &&
+      typeof window !== 'undefined' &&
+      typeof window.umami !== 'undefined'
+    )
+  }
+
+  disable(): void {
+    if (this.config?.debug) {
+      console.log('[Analytics] Umami disabled')
+    }
+
+    this.initialized = false
+    this.scriptLoaded = false
+    this.config = null
+
+    if (typeof document !== 'undefined' && this.scriptElement?.parentNode) {
+      this.scriptElement.parentNode.removeChild(this.scriptElement)
+      this.scriptElement = null
+    }
+
+    if (typeof window !== 'undefined' && window.umami) {
+      delete window.umami
+    }
+  }
+
+  private isDNTEnabled(): boolean {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return false
+    }
+
+    const dnt =
+      navigator.doNotTrack ||
+      (window as Window & { doNotTrack?: string }).doNotTrack ||
+      (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
+
+    return dnt === '1' || dnt === 'yes'
+  }
+}

--- a/src/analytics/providers/utils.test.ts
+++ b/src/analytics/providers/utils.test.ts
@@ -2,24 +2,11 @@
  * Tests for shared analytics provider utilities
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 describe('analytics/providers/utils', () => {
   describe('isDNTEnabled', () => {
-    beforeEach(() => {
-      Object.defineProperty(navigator, 'doNotTrack', {
-        writable: true,
-        configurable: true,
-        value: null,
-      })
-      Object.defineProperty(window, 'doNotTrack', {
-        writable: true,
-        configurable: true,
-        value: null,
-      })
-    })
-
     afterEach(() => {
       Object.defineProperty(navigator, 'doNotTrack', {
         writable: true,

--- a/src/analytics/providers/utils.test.ts
+++ b/src/analytics/providers/utils.test.ts
@@ -2,11 +2,14 @@
  * Tests for shared analytics provider utilities
  */
 
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, afterAll } from 'vitest'
 import { isDNTEnabled, isValidScriptUrl } from './utils'
 
 describe('analytics/providers/utils', () => {
   describe('isDNTEnabled', () => {
+    const originalNavigatorDnt = Object.getOwnPropertyDescriptor(navigator, 'doNotTrack')
+    const originalWindowDnt = Object.getOwnPropertyDescriptor(window, 'doNotTrack')
+
     afterEach(() => {
       Object.defineProperty(navigator, 'doNotTrack', {
         writable: true,
@@ -18,6 +21,22 @@ describe('analytics/providers/utils', () => {
         configurable: true,
         value: null,
       })
+    })
+
+    afterAll(() => {
+      if (originalNavigatorDnt) {
+        Object.defineProperty(navigator, 'doNotTrack', originalNavigatorDnt)
+      } else {
+        Reflect.deleteProperty(
+          navigator as Navigator & { doNotTrack?: string | null },
+          'doNotTrack'
+        )
+      }
+      if (originalWindowDnt) {
+        Object.defineProperty(window, 'doNotTrack', originalWindowDnt)
+      } else {
+        Reflect.deleteProperty(window as Window & { doNotTrack?: string | null }, 'doNotTrack')
+      }
     })
 
     it('should return false when doNotTrack is null', () => {
@@ -43,23 +62,57 @@ describe('analytics/providers/utils', () => {
     })
 
     it('should return true when navigator.doNotTrack is "1"', () => {
-      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+      Object.defineProperty(navigator, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
       expect(isDNTEnabled()).toBe(true)
     })
 
     it('should return true when navigator.doNotTrack is "yes"', () => {
-      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: 'yes' })
+      Object.defineProperty(navigator, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: 'yes',
+      })
       expect(isDNTEnabled()).toBe(true)
     })
 
     it('should return true when window.doNotTrack is "1"', () => {
-      Object.defineProperty(window, 'doNotTrack', { writable: true, value: '1' })
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
       expect(isDNTEnabled()).toBe(true)
     })
 
     it('should return false when doNotTrack is "0"', () => {
-      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '0' })
+      Object.defineProperty(navigator, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '0',
+      })
       expect(isDNTEnabled()).toBe(false)
+    })
+
+    it('should return true when navigator.msDoNotTrack is "1"', () => {
+      const originalMsDnt = Object.getOwnPropertyDescriptor(navigator, 'msDoNotTrack')
+      Object.defineProperty(navigator, 'msDoNotTrack', {
+        writable: true,
+        configurable: true,
+        value: '1',
+      })
+      try {
+        expect(isDNTEnabled()).toBe(true)
+      } finally {
+        if (originalMsDnt) {
+          Object.defineProperty(navigator, 'msDoNotTrack', originalMsDnt)
+        } else {
+          Reflect.deleteProperty(navigator as Navigator & { msDoNotTrack?: string }, 'msDoNotTrack')
+        }
+      }
     })
   })
 

--- a/src/analytics/providers/utils.test.ts
+++ b/src/analytics/providers/utils.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for shared analytics provider utilities
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { isDNTEnabled, isValidScriptUrl } from './utils'
+
+describe('analytics/providers/utils', () => {
+  describe('isDNTEnabled', () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: null,
+      })
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: null,
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(navigator, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: null,
+      })
+      Object.defineProperty(window, 'doNotTrack', {
+        writable: true,
+        configurable: true,
+        value: null,
+      })
+    })
+
+    it('should return false when doNotTrack is null', () => {
+      expect(isDNTEnabled()).toBe(false)
+    })
+
+    it('should return true when navigator.doNotTrack is "1"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
+      expect(isDNTEnabled()).toBe(true)
+    })
+
+    it('should return true when navigator.doNotTrack is "yes"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: 'yes' })
+      expect(isDNTEnabled()).toBe(true)
+    })
+
+    it('should return true when window.doNotTrack is "1"', () => {
+      Object.defineProperty(window, 'doNotTrack', { writable: true, value: '1' })
+      expect(isDNTEnabled()).toBe(true)
+    })
+
+    it('should return false when doNotTrack is "0"', () => {
+      Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '0' })
+      expect(isDNTEnabled()).toBe(false)
+    })
+  })
+
+  describe('isValidScriptUrl', () => {
+    it('should return true for a valid HTTPS .js URL', () => {
+      expect(isValidScriptUrl('https://cdn.example.com/script.js')).toBe(true)
+    })
+
+    it('should return false for an HTTP URL', () => {
+      expect(isValidScriptUrl('http://cdn.example.com/script.js')).toBe(false)
+    })
+
+    it('should return false for a URL without .js extension', () => {
+      expect(isValidScriptUrl('https://cdn.example.com/tracker')).toBe(false)
+    })
+
+    it('should return false for a non-URL string', () => {
+      expect(isValidScriptUrl('not-a-url')).toBe(false)
+    })
+
+    it('should return false for an empty string', () => {
+      expect(isValidScriptUrl('')).toBe(false)
+    })
+
+    it('should return true for provider URLs', () => {
+      expect(isValidScriptUrl('https://plausible.io/js/script.js')).toBe(true)
+      expect(isValidScriptUrl('https://cdn.usefathom.com/script.js')).toBe(true)
+      expect(isValidScriptUrl('https://scripts.simpleanalyticscdn.com/latest.js')).toBe(true)
+    })
+  })
+})

--- a/src/analytics/providers/utils.test.ts
+++ b/src/analytics/providers/utils.test.ts
@@ -24,6 +24,24 @@ describe('analytics/providers/utils', () => {
       expect(isDNTEnabled()).toBe(false)
     })
 
+    it('should return false in SSR environments where navigator is undefined', () => {
+      const original = globalThis.navigator
+      Object.defineProperty(globalThis, 'navigator', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      })
+      try {
+        expect(isDNTEnabled()).toBe(false)
+      } finally {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: original,
+          configurable: true,
+          writable: true,
+        })
+      }
+    })
+
     it('should return true when navigator.doNotTrack is "1"', () => {
       Object.defineProperty(navigator, 'doNotTrack', { writable: true, value: '1' })
       expect(isDNTEnabled()).toBe(true)

--- a/src/analytics/providers/utils.ts
+++ b/src/analytics/providers/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Shared utilities for analytics providers.
  *
- * Centralises Do Not Track detection and script URL validation so all providers
+ * Centralizes Do Not Track detection and script URL validation so all providers
  * behave consistently and updates only need to be made in one place.
  */
 

--- a/src/analytics/providers/utils.ts
+++ b/src/analytics/providers/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared utilities for analytics providers.
+ *
+ * Centralises Do Not Track detection and script URL validation so all providers
+ * behave consistently and updates only need to be made in one place.
+ */
+
+/**
+ * Detect whether the browser's Do Not Track signal is active.
+ * Checks navigator.doNotTrack, window.doNotTrack, and the legacy msDoNotTrack.
+ * Always returns false in SSR / Node.js environments.
+ */
+export function isDNTEnabled(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false
+  }
+
+  const dnt =
+    navigator.doNotTrack ||
+    (window as Window & { doNotTrack?: string }).doNotTrack ||
+    (navigator as Navigator & { msDoNotTrack?: string }).msDoNotTrack
+
+  return dnt === '1' || dnt === 'yes'
+}
+
+/**
+ * Validate a script URL before injecting it as a `<script src>`.
+ * Requires HTTPS protocol and a `.js` file path to guard against script-injection attacks.
+ *
+ * @param url - The URL to validate
+ * @returns true if the URL is safe to inject, false otherwise
+ */
+export function isValidScriptUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:' && parsed.pathname.endsWith('.js')
+  } catch {
+    return false
+  }
+}

--- a/src/analytics/types.ts
+++ b/src/analytics/types.ts
@@ -86,6 +86,14 @@ export interface AnalyticsConfig {
   trackScrollDepth?: boolean
   /** Respect Do Not Track browser setting (default: true) */
   respectDNT?: boolean
+  /**
+   * Fathom-only: mapping from event names to provider-assigned Fathom goal codes.
+   * Fathom goal codes are short IDs created in the Fathom dashboard (e.g. "ABCD1234").
+   * Events whose names are not present in this map will be skipped rather than sent
+   * with an invalid code that Fathom would silently drop.
+   * Example: { cta_click: 'ABCD1234', scroll_depth: 'EFGH5678' }
+   */
+  goalCodes?: Record<string, string>
 }
 
 /**

--- a/src/components/layout/Footer/Footer.module.css
+++ b/src/components/layout/Footer/Footer.module.css
@@ -87,12 +87,24 @@
 }
 
 .linkComingSoon {
-  color: var(--color-text-secondary);
+  /* aria-disabled="true" marks these as inactive UI components (WCAG SC 1.4.3 exemption) */
+  color: var(--color-text-tertiary);
   font-size: var(--font-size-sm);
-  opacity: 0.4;
-  cursor: default;
+  cursor: not-allowed;
   padding: var(--spacing-xs) 0;
   display: inline-block;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .socialIcons {

--- a/src/components/layout/Footer/Footer.module.css
+++ b/src/components/layout/Footer/Footer.module.css
@@ -87,8 +87,12 @@
 }
 
 .linkComingSoon {
-  color: var(--color-text-tertiary);
+  /* Use --color-text-secondary (≥4.5:1 contrast on --color-surface) to satisfy WCAG 2.1 AA
+   * minimum contrast for normal text. Italic + not-allowed cursor convey the
+   * "coming soon / inactive" affordance without relying on low contrast. */
+  color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
+  font-style: italic;
   cursor: not-allowed;
   padding: var(--spacing-xs) 0;
   display: inline-block;

--- a/src/components/layout/Footer/Footer.module.css
+++ b/src/components/layout/Footer/Footer.module.css
@@ -94,18 +94,6 @@
   display: inline-block;
 }
 
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
-
 .socialIcons {
   display: flex;
   gap: var(--spacing-md);

--- a/src/components/layout/Footer/Footer.module.css
+++ b/src/components/layout/Footer/Footer.module.css
@@ -86,6 +86,15 @@
   outline-offset: 2px;
 }
 
+.linkComingSoon {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  opacity: 0.4;
+  cursor: default;
+  padding: var(--spacing-xs) 0;
+  display: inline-block;
+}
+
 .socialIcons {
   display: flex;
   gap: var(--spacing-md);

--- a/src/components/layout/Footer/Footer.module.css
+++ b/src/components/layout/Footer/Footer.module.css
@@ -87,7 +87,6 @@
 }
 
 .linkComingSoon {
-  /* aria-disabled="true" marks these as inactive UI components (WCAG SC 1.4.3 exemption) */
   color: var(--color-text-tertiary);
   font-size: var(--font-size-sm);
   cursor: not-allowed;

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -40,21 +40,13 @@ export const Footer = (): React.ReactElement => {
                   </a>
                 </li>
                 <li>
-                  <span
-                    className={styles.linkComingSoon}
-                    aria-label="Roadmap (coming soon)"
-                    aria-disabled="true"
-                  >
+                  <span className={styles.linkComingSoon}>
                     Roadmap
                     <span className={styles.visuallyHidden}> (coming soon)</span>
                   </span>
                 </li>
                 <li>
-                  <span
-                    className={styles.linkComingSoon}
-                    aria-label="Changelog (coming soon)"
-                    aria-disabled="true"
-                  >
+                  <span className={styles.linkComingSoon}>
                     Changelog
                     <span className={styles.visuallyHidden}> (coming soon)</span>
                   </span>
@@ -71,21 +63,13 @@ export const Footer = (): React.ReactElement => {
                   </a>
                 </li>
                 <li>
-                  <span
-                    className={styles.linkComingSoon}
-                    aria-label="About (coming soon)"
-                    aria-disabled="true"
-                  >
+                  <span className={styles.linkComingSoon}>
                     About
                     <span className={styles.visuallyHidden}> (coming soon)</span>
                   </span>
                 </li>
                 <li>
-                  <span
-                    className={styles.linkComingSoon}
-                    aria-label="Blog (coming soon)"
-                    aria-disabled="true"
-                  >
+                  <span className={styles.linkComingSoon}>
                     Blog
                     <span className={styles.visuallyHidden}> (coming soon)</span>
                   </span>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -39,8 +39,12 @@ export const Footer = (): React.ReactElement => {
                     Pricing
                   </a>
                 </li>
-                {/* TODO: Add Roadmap link when page is available */}
-                {/* TODO: Add Changelog link when page is available */}
+                <li>
+                  <span className={styles.linkComingSoon}>Roadmap</span>
+                </li>
+                <li>
+                  <span className={styles.linkComingSoon}>Changelog</span>
+                </li>
               </ul>
             </div>
 
@@ -52,8 +56,12 @@ export const Footer = (): React.ReactElement => {
                     Contact
                   </a>
                 </li>
-                {/* TODO: Add About link when page is available */}
-                {/* TODO: Add Blog link when page is available */}
+                <li>
+                  <span className={styles.linkComingSoon}>About</span>
+                </li>
+                <li>
+                  <span className={styles.linkComingSoon}>Blog</span>
+                </li>
               </ul>
             </div>
 

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -40,10 +40,24 @@ export const Footer = (): React.ReactElement => {
                   </a>
                 </li>
                 <li>
-                  <span className={styles.linkComingSoon}>Roadmap</span>
+                  <span
+                    className={styles.linkComingSoon}
+                    aria-label="Roadmap (coming soon)"
+                    aria-disabled="true"
+                  >
+                    Roadmap
+                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                  </span>
                 </li>
                 <li>
-                  <span className={styles.linkComingSoon}>Changelog</span>
+                  <span
+                    className={styles.linkComingSoon}
+                    aria-label="Changelog (coming soon)"
+                    aria-disabled="true"
+                  >
+                    Changelog
+                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                  </span>
                 </li>
               </ul>
             </div>
@@ -57,10 +71,24 @@ export const Footer = (): React.ReactElement => {
                   </a>
                 </li>
                 <li>
-                  <span className={styles.linkComingSoon}>About</span>
+                  <span
+                    className={styles.linkComingSoon}
+                    aria-label="About (coming soon)"
+                    aria-disabled="true"
+                  >
+                    About
+                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                  </span>
                 </li>
                 <li>
-                  <span className={styles.linkComingSoon}>Blog</span>
+                  <span
+                    className={styles.linkComingSoon}
+                    aria-label="Blog (coming soon)"
+                    aria-disabled="true"
+                  >
+                    Blog
+                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                  </span>
                 </li>
               </ul>
             </div>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -42,13 +42,13 @@ export const Footer = (): React.ReactElement => {
                 <li>
                   <span className={styles.linkComingSoon}>
                     Roadmap
-                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                    <span className="sr-only"> (coming soon)</span>
                   </span>
                 </li>
                 <li>
                   <span className={styles.linkComingSoon}>
                     Changelog
-                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                    <span className="sr-only"> (coming soon)</span>
                   </span>
                 </li>
               </ul>
@@ -65,13 +65,13 @@ export const Footer = (): React.ReactElement => {
                 <li>
                   <span className={styles.linkComingSoon}>
                     About
-                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                    <span className="sr-only"> (coming soon)</span>
                   </span>
                 </li>
                 <li>
                   <span className={styles.linkComingSoon}>
                     Blog
-                    <span className={styles.visuallyHidden}> (coming soon)</span>
+                    <span className="sr-only"> (coming soon)</span>
                   </span>
                 </li>
               </ul>

--- a/src/constants/__snapshots__/legal.test.ts.snap
+++ b/src/constants/__snapshots__/legal.test.ts.snap
@@ -49,14 +49,19 @@ exports[`Legal Constants > Snapshot Tests > should match needsLegalReview result
 
 exports[`Legal Constants > Snapshot Tests > should match placeholder fields snapshot 1`] = `
 [
-  "Company Legal Name",
-  "Physical Address",
-  "Jurisdiction/Governing Law",
+  "company.legalName",
+  "address.street",
+  "address.city",
+  "address.state",
+  "address.zip",
+  "address.country",
   "documents.cookies",
   "documents.security",
   "documents.dmca",
   "documents.accessibility",
   "social.linkedin",
   "social.discord",
+  "metadata.jurisdiction",
+  "metadata.governingLaw",
 ]
 `;

--- a/src/constants/__snapshots__/legal.test.ts.snap
+++ b/src/constants/__snapshots__/legal.test.ts.snap
@@ -52,5 +52,11 @@ exports[`Legal Constants > Snapshot Tests > should match placeholder fields snap
   "Company Legal Name",
   "Physical Address",
   "Jurisdiction/Governing Law",
+  "documents.cookies",
+  "documents.security",
+  "documents.dmca",
+  "documents.accessibility",
+  "social.linkedin",
+  "social.discord",
 ]
 `;

--- a/src/constants/downloads.ts
+++ b/src/constants/downloads.ts
@@ -1,25 +1,14 @@
 import { LEGAL_CONFIG } from './legal'
 
 /**
- * Download URLs for Paperlyte across different platforms
- *
- * TODO: Update these URLs with actual download links before production release
- * These should point to:
- * - Direct download URLs for installers (.dmg, .exe, .deb, etc.)
- * - App Store / Play Store URLs for mobile platforms
- * - GitHub releases page for source/Linux builds
+ * Download URLs for Paperlyte across different platforms.
+ * Update each URL when the corresponding release or store listing is live.
  */
-
 export const DOWNLOAD_URLS = {
-  // TODO: Update GitHub URL in legal.ts first - currently resolves to "#/releases/..."
   mac: `${LEGAL_CONFIG.social.github}/releases/latest/download/Paperlyte-macOS.dmg`,
-  // TODO: Update GitHub URL in legal.ts first - currently resolves to "#/releases/..."
   windows: `${LEGAL_CONFIG.social.github}/releases/latest/download/Paperlyte-Windows.exe`,
-  // TODO: Replace with actual App Store URL once app is published
   ios: 'https://apps.apple.com/app/paperlyte',
-  // TODO: Replace with actual Play Store URL once app is published
   android: 'https://play.google.com/store/apps/details?id=com.paperlyte.app',
-  // TODO: Update GitHub URL in legal.ts first - currently resolves to "#/releases/..."
   linux: `${LEGAL_CONFIG.social.github}/releases/latest`,
 } as const
 

--- a/src/constants/downloads.ts
+++ b/src/constants/downloads.ts
@@ -1,4 +1,4 @@
-import { LEGAL_CONFIG } from '@constants/legal'
+import { LEGAL_CONFIG } from './legal'
 
 /**
  * Download URLs for Paperlyte across different platforms.

--- a/src/constants/downloads.ts
+++ b/src/constants/downloads.ts
@@ -1,4 +1,4 @@
-import { LEGAL_CONFIG } from './legal'
+import { LEGAL_CONFIG } from '@constants/legal'
 
 /**
  * Download URLs for Paperlyte across different platforms.

--- a/src/constants/legal.test.ts
+++ b/src/constants/legal.test.ts
@@ -247,9 +247,10 @@ describe('Legal Constants', () => {
       expect(placeholders).toContain('Jurisdiction/Governing Law')
     })
 
-    it('should have exactly 3 placeholder fields', () => {
+    it('should include sentinel # links as placeholder fields', () => {
       const placeholders = getPlaceholderFields()
-      expect(placeholders.length).toBe(3)
+      expect(placeholders).toContain('documents.cookies')
+      expect(placeholders).toContain('social.linkedin')
     })
   })
 

--- a/src/constants/legal.test.ts
+++ b/src/constants/legal.test.ts
@@ -232,19 +232,21 @@ describe('Legal Constants', () => {
       })
     })
 
-    it('should identify Company Legal Name as placeholder', () => {
+    it('should identify company.legalName as placeholder', () => {
       const placeholders = getPlaceholderFields()
-      expect(placeholders).toContain('Company Legal Name')
+      expect(placeholders).toContain('company.legalName')
     })
 
-    it('should identify Physical Address as placeholder', () => {
+    it('should identify address fields as placeholders', () => {
       const placeholders = getPlaceholderFields()
-      expect(placeholders).toContain('Physical Address')
+      expect(placeholders).toContain('address.street')
+      expect(placeholders).toContain('address.city')
+      expect(placeholders).toContain('address.state')
     })
 
-    it('should identify Jurisdiction as placeholder', () => {
+    it('should identify metadata.jurisdiction as placeholder', () => {
       const placeholders = getPlaceholderFields()
-      expect(placeholders).toContain('Jurisdiction/Governing Law')
+      expect(placeholders).toContain('metadata.jurisdiction')
     })
 
     it('should include sentinel # links as placeholder fields', () => {

--- a/src/constants/legal.ts
+++ b/src/constants/legal.ts
@@ -60,43 +60,30 @@ export const LEGAL_CONFIG = {
   },
 } as const
 
+const allConfigEntries = (): Array<[string, string]> => {
+  const entries: Array<[string, string]> = []
+  for (const [section, values] of Object.entries(LEGAL_CONFIG)) {
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value === 'string') {
+        entries.push([`${section}.${key}`, value])
+      }
+    }
+  }
+  return entries
+}
+
 /**
  * Helper function to check if legal documents need updating
  */
 export const needsLegalReview = (): boolean => {
-  const hasBracketPlaceholders =
-    LEGAL_CONFIG.company.legalName.includes('[') ||
-    LEGAL_CONFIG.address.street.includes('[') ||
-    LEGAL_CONFIG.metadata.jurisdiction.includes('[')
-
-  const hasSentinelLinks =
-    Object.values(LEGAL_CONFIG.documents).includes('#') ||
-    Object.values(LEGAL_CONFIG.social).includes('#')
-
-  return hasBracketPlaceholders || hasSentinelLinks
+  return allConfigEntries().some(([, value]) => value.includes('[') || value === '#')
 }
 
 /**
  * Get all placeholder fields that need to be filled
  */
 export const getPlaceholderFields = (): string[] => {
-  const placeholders: string[] = []
-
-  if (LEGAL_CONFIG.company.legalName.includes('[')) {
-    placeholders.push('Company Legal Name')
-  }
-  if (LEGAL_CONFIG.address.street.includes('[')) {
-    placeholders.push('Physical Address')
-  }
-  if (LEGAL_CONFIG.metadata.jurisdiction.includes('[')) {
-    placeholders.push('Jurisdiction/Governing Law')
-  }
-  for (const [key, value] of Object.entries(LEGAL_CONFIG.documents)) {
-    if (value === '#') placeholders.push(`documents.${key}`)
-  }
-  for (const [key, value] of Object.entries(LEGAL_CONFIG.social)) {
-    if (value === '#') placeholders.push(`social.${key}`)
-  }
-
-  return placeholders
+  return allConfigEntries()
+    .filter(([, value]) => value.includes('[') || value === '#')
+    .map(([key]) => key)
 }

--- a/src/constants/legal.ts
+++ b/src/constants/legal.ts
@@ -72,11 +72,13 @@ const allConfigEntries = (): Array<[string, string]> => {
   return entries
 }
 
+const isPlaceholder = (value: string): boolean => value.includes('[') || value === '#'
+
 /**
  * Helper function to check if legal documents need updating
  */
 export const needsLegalReview = (): boolean => {
-  return allConfigEntries().some(([, value]) => value.includes('[') || value === '#')
+  return allConfigEntries().some(([, value]) => isPlaceholder(value))
 }
 
 /**
@@ -84,6 +86,6 @@ export const needsLegalReview = (): boolean => {
  */
 export const getPlaceholderFields = (): string[] => {
   return allConfigEntries()
-    .filter(([, value]) => value.includes('[') || value === '#')
+    .filter(([, value]) => isPlaceholder(value))
     .map(([key]) => key)
 }

--- a/src/constants/legal.ts
+++ b/src/constants/legal.ts
@@ -1,7 +1,8 @@
 /**
  * Legal and company information configuration
  *
- * Placeholder values marked with [...] must be replaced before launch.
+ * Placeholder values marked with [...] and sentinel values such as '#'
+ * (for temporary document/social links) must be reviewed and replaced before launch.
  */
 
 export interface CompanyConfig {

--- a/src/constants/legal.ts
+++ b/src/constants/legal.ts
@@ -1,7 +1,7 @@
 /**
  * Legal and company information configuration
  *
- * TODO: Update these values with your actual company information
+ * Placeholder values marked with [...] must be replaced before launch.
  */
 
 export interface CompanyConfig {
@@ -19,7 +19,7 @@ export interface CompanyConfig {
 export const LEGAL_CONFIG = {
   company: {
     name: 'Paperlyte',
-    legalName: '[Company Legal Name]', // TODO: Add legal entity name
+    legalName: '[Company Legal Name]',
     email: 'hello@paperlyte.com',
     supportEmail: 'support@paperlyte.com',
     privacyEmail: 'privacy@paperlyte.com',
@@ -29,7 +29,7 @@ export const LEGAL_CONFIG = {
     arbitrationOptOutEmail: 'arbitration-opt-out@paperlyte.com',
   },
   address: {
-    street: '[Street Address]', // TODO: Add street address
+    street: '[Street Address]',
     city: '[City]',
     state: '[State]',
     zip: '[ZIP]',
@@ -38,24 +38,24 @@ export const LEGAL_CONFIG = {
   documents: {
     privacy: '/privacy.html',
     terms: '/terms.html',
-    cookies: '#', // TODO: Create cookie policy
-    security: '#', // TODO: Create security practices doc
-    dmca: '#', // TODO: Create DMCA policy
-    accessibility: '#', // TODO: Create accessibility statement
+    cookies: '#',
+    security: '#',
+    dmca: '#',
+    accessibility: '#',
   },
   social: {
     github: 'https://github.com/shazzar00ni/paperlyte-v2',
     twitter: 'https://x.com/paperlyte',
-    linkedin: '#', // TODO: Create LinkedIn company page or update to existing page
+    linkedin: '#',
     instagram: 'https://instagram.com/paperlytefilms',
-    discord: '#', // TODO: Add Discord server link
+    discord: '#',
   },
   metadata: {
     privacyLastUpdated: '2025-11-28',
     termsLastUpdated: '2025-11-28',
     termsVersion: '1.0',
-    jurisdiction: '[State/Country]', // TODO: Add jurisdiction
-    governingLaw: '[State] law', // TODO: Add governing law
+    jurisdiction: '[State/Country]',
+    governingLaw: '[State] law',
   },
 } as const
 

--- a/src/constants/legal.ts
+++ b/src/constants/legal.ts
@@ -64,12 +64,16 @@ export const LEGAL_CONFIG = {
  * Helper function to check if legal documents need updating
  */
 export const needsLegalReview = (): boolean => {
-  const hasPlaceholders =
+  const hasBracketPlaceholders =
     LEGAL_CONFIG.company.legalName.includes('[') ||
     LEGAL_CONFIG.address.street.includes('[') ||
     LEGAL_CONFIG.metadata.jurisdiction.includes('[')
 
-  return hasPlaceholders
+  const hasSentinelLinks =
+    Object.values(LEGAL_CONFIG.documents).includes('#') ||
+    Object.values(LEGAL_CONFIG.social).includes('#')
+
+  return hasBracketPlaceholders || hasSentinelLinks
 }
 
 /**
@@ -86,6 +90,12 @@ export const getPlaceholderFields = (): string[] => {
   }
   if (LEGAL_CONFIG.metadata.jurisdiction.includes('[')) {
     placeholders.push('Jurisdiction/Governing Law')
+  }
+  for (const [key, value] of Object.entries(LEGAL_CONFIG.documents)) {
+    if (value === '#') placeholders.push(`documents.${key}`)
+  }
+  for (const [key, value] of Object.entries(LEGAL_CONFIG.social)) {
+    if (value === '#') placeholders.push(`social.${key}`)
   }
 
   return placeholders

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -30,6 +30,7 @@ interface Window {
   umami?: {
     track(eventName: string, props?: Record<string, string | number | boolean>): void
     track(data: { url?: string; referrer?: string; title?: string }): void
+    track(callback: (props: Record<string, unknown>) => Record<string, unknown>): void
     identify(sessionData: Record<string, string | number | boolean>): void
   }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,4 +17,23 @@ interface Window {
       callback?: () => void
     }
   ) => void
+
+  // Fathom Analytics
+  fathom?: {
+    trackPageview(options?: { url?: string; referrer?: string }): void
+    trackGoal(code: string, cents?: number, props?: Record<string, string | number | boolean>): void
+    enableTrackingForMe(): void
+    blockTrackingForMe(): void
+  }
+
+  // Umami Analytics
+  umami?: {
+    track(eventName: string, props?: Record<string, string | number | boolean>): void
+    track(data: { url?: string; referrer?: string; title?: string }): void
+    identify(sessionData: Record<string, string | number | boolean>): void
+  }
+
+  // Simple Analytics
+  sa_event?: (eventName: string, props?: Record<string, string | number | boolean>) => void
+  sa_pageview?: (path: string) => void
 }


### PR DESCRIPTION
## Summary

This PR implements three new analytics providers — Fathom, Umami, and Simple Analytics — completing the provider matrix that previously only supported Plausible. It also refactors legal placeholder detection and replaces Footer TODOs with visible "coming soon" placeholders.

## Changes

- **Analytics providers**: Implement `FathomProvider`, `UmamiProvider`, and `SimpleAnalyticsProvider` — the `createProvider` switch in `analytics/index.ts` previously threw an error for these values; they now work fully following the same pattern as the existing `PlausibleProvider`
- **Global types**: Add `window.fathom`, `window.umami`, `window.sa_event`, and `window.sa_pageview` declarations to `global.d.ts` so TypeScript resolves the new provider calls cleanly
- **Footer**: Replace four `{/* TODO: Add X link when page is available */}` comments with rendered `<span class="linkComingSoon">` items (Roadmap, Changelog, About, Blog) so the footer reflects planned content without dead links; add matching `.linkComingSoon` CSS style (muted, non-interactive)
- **legal.ts / downloads.ts**: Strip TODO noise from inline comments; placeholder bracket values (`[Company Legal Name]`, `[Street Address]`, etc.) remain for real business data to fill in before launch

## Test plan

- [x] Set `VITE_ANALYTICS_PROVIDER=fathom` / `umami` / `simple` in `.env` — verify no thrown error on init
- [x] Confirm `window.fathom`, `window.umami`, `window.sa_event` TypeScript types resolve without errors (`npx tsc -p tsconfig.app.json --noEmit`)
- [x] View footer in browser — Roadmap, Changelog, About, Blog appear muted and are not clickable
- [x] Confirm no regressions in existing Plausible provider path

---

## Details

All three providers follow a shared pattern:

```
class XProvider implements AnalyticsProvider {
  init(config)    // DNT check → validate scriptUrl
                  //   → inject <script> → onload/onerror
  trackPageView(url?)        // guard isEnabled()
  trackEvent(event)          // sanitize props via
                             //   isSafePropertyKey()
  trackWebVitals(vitals)     // provider-specific
  isEnabled()    // initialized && scriptLoaded
                 //   && window.X?.method is fn
  disable()      // remove script, delete window.X
}

```
## Key provider-specific differences:

- Fathom: uses goal codes (not arbitrary event names); trackWebVitals is a no-op (requires explicit goal-code mapping)
- Umami: scriptUrl is required (self-hosted); no default CDN fallback
- Simple Analytics: auto-detects domain; replaces spaces with underscores in event names
- Separately, LEGAL_CONFIG placeholder detection is generalized from 3 hardcoded checks to a full scan of all config entries, and the Footer now renders disabled "coming soon" links instead of HTML comments.

_Generated by [Claude Code](https://claude.ai/code/session_01RM4w7v9V9zFy81kVczVX9h)_