### PR TITLE
perf: code-split below-the-fold sections and defer Sentry Replay (#816)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -240,8 +240,11 @@ describe('App Integration', () => {
     expect(feedbackButton).toBeInTheDocument()
   })
 
-  it('should not have any duplicate IDs', () => {
+  it('should not have any duplicate IDs', async () => {
     const { container } = render(<App />)
+
+    // Wait for all lazy sections so their IDs are included in the check
+    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
 
     const elementsWithId = container.querySelectorAll('[id]')
     const ids = Array.from(elementsWithId).map((el) => el.getAttribute('id'))
@@ -272,13 +275,22 @@ describe('App Integration', () => {
   it('should render without console errors', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    const { container } = render(<App />)
-    // Flush all lazy-loaded sections to prevent act() warnings from polluting the spy
-    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
+    try {
+      const { container } = render(<App />)
+      // Flush ALL lazy-loaded sections so none resolve after the assertion and emit act() warnings
+      await waitFor(() => {
+        expect(container.querySelector('#statistics')).toBeInTheDocument()
+        expect(container.querySelector('#comparison')).toBeInTheDocument()
+        expect(container.querySelector('#testimonials')).toBeInTheDocument()
+        expect(container.querySelector('#email-capture')).toBeInTheDocument()
+        expect(container.querySelector('#faq')).toBeInTheDocument()
+        expect(container.querySelector('#download')).toBeInTheDocument()
+      })
 
-    expect(consoleErrorSpy).not.toHaveBeenCalled()
-
-    consoleErrorSpy.mockRestore()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   it('should render all major UI components', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from './App'
+import { _clearPendingScrollObservers } from '@utils/navigation'
 
 describe('App Integration', () => {
+  afterEach(() => {
+    // Clear any module-level MutationObservers created by scrollToSection in
+    // components under test — prevents observer leakage across tests.
+    _clearPendingScrollObservers()
+  })
+
   it('should render with proper semantic structure and section order', async () => {
     const { container } = render(<App />)
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -141,14 +141,13 @@ describe('App Integration', () => {
   })
 
   it('should render CTA buttons in download section', async () => {
-    render(<App />)
+    const { container } = render(<App />)
 
-    // Wait for lazy CTA section to render
-    await waitFor(() =>
-      expect(screen.getAllByRole('button', { name: /Join the Waitlist/i }).length).toBeGreaterThan(
-        0
-      )
-    )
+    // Wait for the lazy #download section specifically (not a button that also exists in eager sections)
+    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
+
+    // Check for actual CTA buttons (there may be multiple "Join the Waitlist" buttons across sections)
+    expect(screen.getAllByRole('button', { name: /Join the Waitlist/i }).length).toBeGreaterThan(0)
 
     // Check for demo button (use flexible pattern to handle different wording)
     const demoButtons = screen.getAllByRole('button', { name: /Watch the Demo|View the Demo/i })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,13 +20,15 @@ describe('App Integration', () => {
     // Verify header contains navigation
     expect(header?.querySelector('nav')).toBeInTheDocument()
 
-    // Wait for lazy-loaded sections to render before checking order
-    await waitFor(() => expect(container.querySelector('#statistics')).toBeInTheDocument())
-    await waitFor(() => expect(container.querySelector('#comparison')).toBeInTheDocument())
-    await waitFor(() => expect(container.querySelector('#testimonials')).toBeInTheDocument())
-    await waitFor(() => expect(container.querySelector('#email-capture')).toBeInTheDocument())
-    await waitFor(() => expect(container.querySelector('#faq')).toBeInTheDocument())
-    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
+    // Wait for all lazy-loaded sections to render before checking order
+    await waitFor(() => {
+      expect(container.querySelector('#statistics')).toBeInTheDocument()
+      expect(container.querySelector('#comparison')).toBeInTheDocument()
+      expect(container.querySelector('#testimonials')).toBeInTheDocument()
+      expect(container.querySelector('#email-capture')).toBeInTheDocument()
+      expect(container.querySelector('#faq')).toBeInTheDocument()
+      expect(container.querySelector('#download')).toBeInTheDocument()
+    })
 
     // Verify sections exist and are in correct order
     const sections = main?.querySelectorAll('section')
@@ -260,18 +262,19 @@ describe('App Integration', () => {
   it('should include waitlist form in EmailCapture section', async () => {
     const { container } = render(<App />)
 
-    // EmailCapture section should contain email input (lazy-loaded)
-    await waitFor(() =>
-      expect(container.querySelectorAll('input[type="email"]').length).toBeGreaterThan(0)
-    )
+    // Wait for the lazy #email-capture section specifically
+    await waitFor(() => expect(container.querySelector('#email-capture')).toBeInTheDocument())
+
+    const emailCaptureSection = container.querySelector('#email-capture')
+    expect(emailCaptureSection?.querySelector('input[type="email"]')).toBeInTheDocument()
   })
 
   it('should render without console errors', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     const { container } = render(<App />)
-    // Flush lazy-loaded sections to prevent act() warnings from polluting the spy
-    await waitFor(() => expect(container.querySelector('#statistics')).toBeInTheDocument())
+    // Flush all lazy-loaded sections to prevent act() warnings from polluting the spy
+    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
 
     expect(consoleErrorSpy).not.toHaveBeenCalled()
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -244,7 +244,14 @@ describe('App Integration', () => {
     const { container } = render(<App />)
 
     // Wait for all lazy sections so their IDs are included in the check
-    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
+    await waitFor(() => {
+      expect(container.querySelector('#statistics')).toBeInTheDocument()
+      expect(container.querySelector('#comparison')).toBeInTheDocument()
+      expect(container.querySelector('#testimonials')).toBeInTheDocument()
+      expect(container.querySelector('#email-capture')).toBeInTheDocument()
+      expect(container.querySelector('#faq')).toBeInTheDocument()
+      expect(container.querySelector('#download')).toBeInTheDocument()
+    })
 
     const elementsWithId = container.querySelectorAll('[id]')
     const ids = Array.from(elementsWithId).map((el) => el.getAttribute('id'))

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -262,7 +262,9 @@ describe('App Integration', () => {
     const { container } = render(<App />)
 
     // EmailCapture section should contain email input (lazy-loaded)
-    await waitFor(() => expect(container.querySelectorAll('input[type="email"]').length).toBeGreaterThan(0))
+    await waitFor(() =>
+      expect(container.querySelectorAll('input[type="email"]').length).toBeGreaterThan(0)
+    )
   })
 
   it('should render without console errors', async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from './App'
 
 describe('App Integration', () => {
-  it('should render with proper semantic structure and section order', () => {
+  it('should render with proper semantic structure and section order', async () => {
     const { container } = render(<App />)
 
     // Verify semantic landmark regions
@@ -19,6 +19,14 @@ describe('App Integration', () => {
 
     // Verify header contains navigation
     expect(header?.querySelector('nav')).toBeInTheDocument()
+
+    // Wait for lazy-loaded sections to render before checking order
+    await waitFor(() => expect(container.querySelector('#statistics')).toBeInTheDocument())
+    await waitFor(() => expect(container.querySelector('#comparison')).toBeInTheDocument())
+    await waitFor(() => expect(container.querySelector('#testimonials')).toBeInTheDocument())
+    await waitFor(() => expect(container.querySelector('#email-capture')).toBeInTheDocument())
+    await waitFor(() => expect(container.querySelector('#faq')).toBeInTheDocument())
+    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
 
     // Verify sections exist and are in correct order
     const sections = main?.querySelectorAll('section')
@@ -104,21 +112,19 @@ describe('App Integration', () => {
     expect(screen.getByText(/Capture inspiration/i)).toBeInTheDocument()
   })
 
-  it('should render Testimonials section', () => {
+  it('should render Testimonials section', async () => {
     const { container } = render(<App />)
 
-    const testimonialsSection = container.querySelector('#testimonials')
-    expect(testimonialsSection).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector('#testimonials')).toBeInTheDocument())
 
     // Verify testimonials content is present
     expect(screen.getByText(/Sarah Chen/i)).toBeInTheDocument()
   })
 
-  it('should render CTA section', () => {
+  it('should render CTA section', async () => {
     const { container } = render(<App />)
 
-    const ctaSection = container.querySelector('#download')
-    expect(ctaSection).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector('#download')).toBeInTheDocument())
 
     // Verify specific CTA content is present
     expect(screen.getByText(/Stop fighting your tools/i)).toBeInTheDocument()
@@ -134,11 +140,15 @@ describe('App Integration', () => {
     expect(screen.getByRole('contentinfo')).toBeInTheDocument()
   })
 
-  it('should render CTA buttons in download section', () => {
+  it('should render CTA buttons in download section', async () => {
     render(<App />)
 
-    // Check for actual CTA buttons (there may be multiple "Join the Waitlist" buttons across sections)
-    expect(screen.getAllByRole('button', { name: /Join the Waitlist/i }).length).toBeGreaterThan(0)
+    // Wait for lazy CTA section to render
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /Join the Waitlist/i }).length).toBeGreaterThan(
+        0
+      )
+    )
 
     // Check for demo button (use flexible pattern to handle different wording)
     const demoButtons = screen.getAllByRole('button', { name: /Watch the Demo|View the Demo/i })
@@ -203,25 +213,22 @@ describe('App Integration', () => {
     expect(solutionSection).toBeInTheDocument()
   })
 
-  it('should render Statistics section', () => {
+  it('should render Statistics section', async () => {
     const { container } = render(<App />)
 
-    const statisticsSection = container.querySelector('#statistics')
-    expect(statisticsSection).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector('#statistics')).toBeInTheDocument())
   })
 
-  it('should render Comparison section', () => {
+  it('should render Comparison section', async () => {
     const { container } = render(<App />)
 
-    const comparisonSection = container.querySelector('#comparison')
-    expect(comparisonSection).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector('#comparison')).toBeInTheDocument())
   })
 
-  it('should render FAQ section', () => {
+  it('should render FAQ section', async () => {
     const { container } = render(<App />)
 
-    const faqSection = container.querySelector('#faq')
-    expect(faqSection).toBeInTheDocument()
+    await waitFor(() => expect(container.querySelector('#faq')).toBeInTheDocument())
   })
 
   it('should render FeedbackWidget component', () => {
@@ -251,18 +258,19 @@ describe('App Integration', () => {
     expect(h1Elements.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('should include waitlist form in EmailCapture section', () => {
+  it('should include waitlist form in EmailCapture section', async () => {
     const { container } = render(<App />)
 
-    // EmailCapture section should contain email input
-    const emailInputs = container.querySelectorAll('input[type="email"]')
-    expect(emailInputs.length).toBeGreaterThan(0)
+    // EmailCapture section should contain email input (lazy-loaded)
+    await waitFor(() => expect(container.querySelectorAll('input[type="email"]').length).toBeGreaterThan(0))
   })
 
-  it('should render without console errors', () => {
+  it('should render without console errors', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    render(<App />)
+    const { container } = render(<App />)
+    // Flush lazy-loaded sections to prevent act() warnings from polluting the spy
+    await waitFor(() => expect(container.querySelector('#statistics')).toBeInTheDocument())
 
     expect(consoleErrorSpy).not.toHaveBeenCalled()
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, lazy, Suspense } from 'react'
 import { ErrorBoundary } from '@components/ErrorBoundary'
 import { Header } from '@components/layout/Header'
 import { Footer } from '@components/layout/Footer'
@@ -7,14 +7,23 @@ import { Problem } from '@components/sections/Problem'
 import { Solution } from '@components/sections/Solution'
 import { Features } from '@components/sections/Features'
 import { Mobile } from '@components/sections/Mobile'
-import { Statistics } from '@components/sections/Statistics'
-import { Comparison } from '@components/sections/Comparison'
-import { Testimonials } from '@components/sections/Testimonials'
-import { EmailCapture } from '@components/sections/EmailCapture'
-import { FAQ } from '@components/sections/FAQ'
-import { CTA } from '@components/sections/CTA'
 import { FeedbackWidget } from '@components/ui/FeedbackWidget'
 import { useAnalytics } from '@hooks/useAnalytics'
+
+const Statistics = lazy(() =>
+  import('@components/sections/Statistics').then((m) => ({ default: m.Statistics }))
+)
+const Comparison = lazy(() =>
+  import('@components/sections/Comparison').then((m) => ({ default: m.Comparison }))
+)
+const Testimonials = lazy(() =>
+  import('@components/sections/Testimonials').then((m) => ({ default: m.Testimonials }))
+)
+const EmailCapture = lazy(() =>
+  import('@components/sections/EmailCapture').then((m) => ({ default: m.EmailCapture }))
+)
+const FAQ = lazy(() => import('@components/sections/FAQ').then((m) => ({ default: m.FAQ })))
+const CTA = lazy(() => import('@components/sections/CTA').then((m) => ({ default: m.CTA })))
 
 /**
  * Application root component that composes the page layout and sections.
@@ -45,12 +54,14 @@ function App() {
         <Solution />
         <Features />
         <Mobile />
-        <Statistics />
-        <Comparison />
-        <Testimonials />
-        <EmailCapture />
-        <FAQ />
-        <CTA />
+        <Suspense fallback={null}>
+          <Statistics />
+          <Comparison />
+          <Testimonials />
+          <EmailCapture />
+          <FAQ />
+          <CTA />
+        </Suspense>
       </main>
       <Footer />
       <FeedbackWidget />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,32 +54,32 @@ function App() {
         <Solution />
         <Features />
         <Mobile />
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <Statistics />
           </Suspense>
         </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <Comparison />
           </Suspense>
         </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <Testimonials />
           </Suspense>
         </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <EmailCapture />
           </Suspense>
         </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <FAQ />
           </Suspense>
         </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
+        <ErrorBoundary fallback={<></>}>
           <Suspense fallback={null}>
             <CTA />
           </Suspense>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,21 +63,11 @@ function App() {
         <Suspense fallback={null}>
           <Testimonials />
         </Suspense>
-          <Statistics />
-        </Suspense>
-        <Suspense fallback={null}>
-          <Comparison />
-        </Suspense>
-        <Suspense fallback={null}>
-          <Testimonials />
-        </Suspense>
         <Suspense fallback={null}>
           <EmailCapture />
         </Suspense>
         <Suspense fallback={null}>
           <FAQ />
-        </Suspense>
-        <Suspense fallback={null}>
         </Suspense>
         <Suspense fallback={null}>
           <CTA />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,10 +56,20 @@ function App() {
         <Mobile />
         <Suspense fallback={null}>
           <Statistics />
+        </Suspense>
+        <Suspense fallback={null}>
           <Comparison />
+        </Suspense>
+        <Suspense fallback={null}>
           <Testimonials />
+        </Suspense>
+        <Suspense fallback={null}>
           <EmailCapture />
+        </Suspense>
+        <Suspense fallback={null}>
           <FAQ />
+        </Suspense>
+        <Suspense fallback={null}>
           <CTA />
         </Suspense>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,11 +63,21 @@ function App() {
         <Suspense fallback={null}>
           <Testimonials />
         </Suspense>
+          <Statistics />
+        </Suspense>
+        <Suspense fallback={null}>
+          <Comparison />
+        </Suspense>
+        <Suspense fallback={null}>
+          <Testimonials />
+        </Suspense>
         <Suspense fallback={null}>
           <EmailCapture />
         </Suspense>
         <Suspense fallback={null}>
           <FAQ />
+        </Suspense>
+        <Suspense fallback={null}>
         </Suspense>
         <Suspense fallback={null}>
           <CTA />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,24 +54,36 @@ function App() {
         <Solution />
         <Features />
         <Mobile />
-        <Suspense fallback={null}>
-          <Statistics />
-        </Suspense>
-        <Suspense fallback={null}>
-          <Comparison />
-        </Suspense>
-        <Suspense fallback={null}>
-          <Testimonials />
-        </Suspense>
-        <Suspense fallback={null}>
-          <EmailCapture />
-        </Suspense>
-        <Suspense fallback={null}>
-          <FAQ />
-        </Suspense>
-        <Suspense fallback={null}>
-          <CTA />
-        </Suspense>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <Statistics />
+          </Suspense>
+        </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <Comparison />
+          </Suspense>
+        </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <Testimonials />
+          </Suspense>
+        </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <EmailCapture />
+          </Suspense>
+        </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <FAQ />
+          </Suspense>
+        </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <Suspense fallback={null}>
+            <CTA />
+          </Suspense>
+        </ErrorBoundary>
       </main>
       <Footer />
       <FeedbackWidget />

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -92,8 +92,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   render(): ReactNode {
     if (this.state.hasError) {
-      // Use custom fallback if provided
-      if (this.props.fallback) {
+      // Use custom fallback if provided (including null to render nothing)
+      if (this.props.fallback !== undefined) {
         return this.props.fallback
       }
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -7,6 +7,7 @@ import {
   handleArrowNavigation,
   handleHomeEndNavigation,
 } from '@utils/keyboard'
+import { scrollToSection as scrollToSectionUtil } from '@utils/navigation'
 import styles from './Header.module.css'
 
 /**
@@ -43,11 +44,12 @@ export const Header = (): React.ReactElement => {
 
   const scrollToSection = useCallback(
     (sectionId: string) => {
-      const element = document.getElementById(sectionId)
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth' })
-        closeMobileMenu()
-      }
+      // Use the shared utility so lazy-loaded sections (e.g. #download) are
+      // observed and scrolled to once their chunk mounts.
+      scrollToSectionUtil(sectionId)
+      // Close the mobile menu regardless of whether the section is mounted yet —
+      // otherwise the menu would stay open while waiting for a lazy chunk.
+      closeMobileMenu()
     },
     [closeMobileMenu]
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -50,9 +50,9 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       })
   }
 
-  // Cast to Record to avoid TypeScript narrowing `requestIdleCallback` as always-present
-  // (TS 6 marks it as required on Window, making the else-branches unreachable otherwise)
-  if ('requestIdleCallback' in (window as Record<string, unknown>)) {
+  // Use unknown intermediate cast — TS marks requestIdleCallback as required on Window in 5.9,
+  // making the else-branches unreachable if we narrow window directly with `in`.
+  if ('requestIdleCallback' in (window as unknown as Record<string, unknown>)) {
     window.requestIdleCallback(loadReplay)
   } else if (document.readyState === 'complete') {
     window.setTimeout(loadReplay, 0)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -50,9 +50,7 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       })
   }
 
-  if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(() => loadReplay())
-  } else if (document.readyState === 'complete') {
+  if (document.readyState === 'complete') {
     window.setTimeout(loadReplay, 0)
   } else {
     window.addEventListener('load', loadReplay, { once: true })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -56,7 +56,8 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   }
 
   if (typeof window.requestIdleCallback === 'function') {
-    window.requestIdleCallback(loadReplay)
+    // Timeout ensures replay eventually loads even on a busy main thread
+    window.requestIdleCallback(loadReplay, { timeout: 2000 })
   } else if (document.readyState === 'complete') {
     window.setTimeout(loadReplay, 0)
   } else {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,10 +40,22 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
     },
   })
 
-  if (typeof window !== 'undefined') {
-    import('@sentry/react').then(({ replayIntegration }) => {
-      Sentry.addIntegration(replayIntegration({ maskAllText: true, blockAllMedia: true }))
-    })
+  const loadReplay = () => {
+    import('@sentry/react')
+      .then(({ replayIntegration }) => {
+        Sentry.addIntegration(replayIntegration({ maskAllText: true, blockAllMedia: true }))
+      })
+      .catch((error) => {
+        console.error('Failed to load Sentry Replay integration', error)
+      })
+  }
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(() => loadReplay())
+  } else if (document.readyState === 'complete') {
+    window.setTimeout(loadReplay, 0)
+  } else {
+    window.addEventListener('load', loadReplay, { once: true })
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,13 +19,7 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
-    integrations: [
-      Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration({
-        maskAllText: true,
-        blockAllMedia: true,
-      }),
-    ],
+    integrations: [Sentry.browserTracingIntegration()],
     // Performance monitoring
     tracesSampleRate: parseFloat(import.meta.env.VITE_SENTRY_SAMPLE_RATE || '0.1'),
     // Session replay
@@ -45,6 +39,12 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       return event
     },
   })
+
+  if (typeof window !== 'undefined') {
+    import('@sentry/react').then(({ replayIntegration }) => {
+      Sentry.addIntegration(replayIntegration({ maskAllText: true, blockAllMedia: true }))
+    })
+  }
 }
 
 // Initialize environment-aware meta tags

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -41,7 +41,7 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
   })
 
   const loadReplay = () => {
-    import('@sentry/react')
+    import('@sentry/browser')
       .then(({ replayIntegration }) => {
         Sentry.addIntegration(replayIntegration({ maskAllText: true, blockAllMedia: true }))
       })
@@ -50,7 +50,11 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       })
   }
 
-  if (document.readyState === 'complete') {
+  // Cast to Record to avoid TypeScript narrowing `requestIdleCallback` as always-present
+  // (TS 6 marks it as required on Window, making the else-branches unreachable otherwise)
+  if ('requestIdleCallback' in (window as Record<string, unknown>)) {
+    window.requestIdleCallback(loadReplay)
+  } else if (document.readyState === 'complete') {
     window.setTimeout(loadReplay, 0)
   } else {
     window.addEventListener('load', loadReplay, { once: true })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import * as Sentry from '@sentry/react'
+import * as monitoring from '@utils/monitoring'
 // Self-hosted Google Fonts (Inter) for better security and performance
 // Using Latin-only subset to reduce bundle size (~800 KB savings)
 import '@fontsource/inter/latin-400.css'
@@ -45,8 +46,12 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       .then(({ replayIntegration }) => {
         Sentry.addIntegration(replayIntegration({ maskAllText: true, blockAllMedia: true }))
       })
-      .catch((error) => {
-        console.error('Failed to load Sentry Replay integration', error)
+      .catch((error: unknown) => {
+        monitoring.logError(
+          error instanceof Error ? error : new Error(String(error)),
+          { errorInfo: { component: 'loadReplay', action: 'import-replay' }, severity: 'medium' },
+          'loadReplay'
+        )
       })
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -55,9 +55,7 @@ if (import.meta.env.PROD && import.meta.env.VITE_SENTRY_DSN) {
       })
   }
 
-  // Use unknown intermediate cast — TS marks requestIdleCallback as required on Window in 5.9,
-  // making the else-branches unreachable if we narrow window directly with `in`.
-  if ('requestIdleCallback' in (window as unknown as Record<string, unknown>)) {
+  if (typeof window.requestIdleCallback === 'function') {
     window.requestIdleCallback(loadReplay)
   } else if (document.readyState === 'complete') {
     window.setTimeout(loadReplay, 0)

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   scrollToSection,
+  _clearPendingScrollObservers,
   isSafeUrl,
   safeNavigate,
   hasDangerousProtocol,
@@ -12,6 +13,11 @@ describe('navigation utilities', () => {
   describe('scrollToSection', () => {
     beforeEach(() => {
       vi.clearAllMocks()
+    })
+
+    afterEach(() => {
+      // Cancel any MutationObservers left pending when a section ID wasn't found
+      _clearPendingScrollObservers()
     })
 
     it('should scroll to element when it exists', () => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,9 +1,23 @@
 const SCROLL_RETRY_TIMEOUT_MS = 5000
 
+// Tracks in-flight observers keyed by sectionId — ensures rapid repeat calls to
+// the same target cancel the previous observer instead of accumulating observers.
+const pendingScrollObservers = new Map<string, { observer: MutationObserver; timeoutId: number }>()
+
+function cancelPendingScroll(sectionId: string): void {
+  const pending = pendingScrollObservers.get(sectionId)
+  if (pending) {
+    pending.observer.disconnect()
+    clearTimeout(pending.timeoutId)
+    pendingScrollObservers.delete(sectionId)
+  }
+}
+
 /**
  * Scrolls smoothly to a section identified by its ID.
  * If the section is not yet in the DOM (e.g. still loading as a lazy chunk),
- * waits up to 5 s for it to appear before scrolling.
+ * waits up to 5 s for it to appear before scrolling. Rapid repeat calls for
+ * the same target cancel the previous pending scroll to avoid stacking observers.
  *
  * @param sectionId - The ID of the section to scroll to (without the # prefix)
  */
@@ -15,21 +29,25 @@ export function scrollToSection(sectionId: string): void {
 
   const element = document.getElementById(sectionId)
   if (element) {
+    cancelPendingScroll(sectionId)
     element.scrollIntoView({ behavior: 'smooth' })
     return
   }
+
+  // Cancel any previous pending observer for this target before creating a new one
+  cancelPendingScroll(sectionId)
 
   // Section not yet mounted — observe DOM until it appears (handles lazy chunks)
   const observer = new MutationObserver(() => {
     const el = document.getElementById(sectionId)
     if (el) {
-      observer.disconnect()
-      clearTimeout(timeoutId)
+      cancelPendingScroll(sectionId)
       el.scrollIntoView({ behavior: 'smooth' })
     }
   })
 
-  const timeoutId = setTimeout(() => observer.disconnect(), SCROLL_RETRY_TIMEOUT_MS)
+  const timeoutId = window.setTimeout(() => cancelPendingScroll(sectionId), SCROLL_RETRY_TIMEOUT_MS)
+  pendingScrollObservers.set(sectionId, { observer, timeoutId })
   observer.observe(document.body, { childList: true, subtree: true })
 }
 

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,6 +1,9 @@
+const SCROLL_RETRY_TIMEOUT_MS = 5000
+
 /**
  * Scrolls smoothly to a section identified by its ID.
- * If the section doesn't exist or running in SSR, the function does nothing.
+ * If the section is not yet in the DOM (e.g. still loading as a lazy chunk),
+ * waits up to 5 s for it to appear before scrolling.
  *
  * @param sectionId - The ID of the section to scroll to (without the # prefix)
  */
@@ -13,7 +16,21 @@ export function scrollToSection(sectionId: string): void {
   const element = document.getElementById(sectionId)
   if (element) {
     element.scrollIntoView({ behavior: 'smooth' })
+    return
   }
+
+  // Section not yet mounted — observe DOM until it appears (handles lazy chunks)
+  const observer = new MutationObserver(() => {
+    const el = document.getElementById(sectionId)
+    if (el) {
+      observer.disconnect()
+      clearTimeout(timeoutId)
+      el.scrollIntoView({ behavior: 'smooth' })
+    }
+  })
+
+  const timeoutId = setTimeout(() => observer.disconnect(), SCROLL_RETRY_TIMEOUT_MS)
+  observer.observe(document.body, { childList: true, subtree: true })
 }
 
 /**

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -2,7 +2,10 @@ const SCROLL_RETRY_TIMEOUT_MS = 5000
 
 // Tracks in-flight observers keyed by sectionId — ensures rapid repeat calls to
 // the same target cancel the previous observer instead of accumulating observers.
-const pendingScrollObservers = new Map<string, { observer: MutationObserver; timeoutId: number }>()
+const pendingScrollObservers = new Map<
+  string,
+  { observer: MutationObserver; timeoutId: ReturnType<typeof setTimeout> }
+>()
 
 function cancelPendingScroll(sectionId: string): void {
   const pending = pendingScrollObservers.get(sectionId)
@@ -37,7 +40,9 @@ export function scrollToSection(sectionId: string): void {
   // Cancel any previous pending observer for this target before creating a new one
   cancelPendingScroll(sectionId)
 
-  // Section not yet mounted — observe DOM until it appears (handles lazy chunks)
+  // Section not yet mounted — observe DOM until it appears (handles lazy chunks).
+  // Scope to #main to avoid firing on unrelated mutations (header, overlays, etc.).
+  const root = document.getElementById('main') ?? document.body
   const observer = new MutationObserver(() => {
     const el = document.getElementById(sectionId)
     if (el) {
@@ -46,9 +51,11 @@ export function scrollToSection(sectionId: string): void {
     }
   })
 
-  const timeoutId = window.setTimeout(() => cancelPendingScroll(sectionId), SCROLL_RETRY_TIMEOUT_MS)
+  const timeoutId = setTimeout(() => cancelPendingScroll(sectionId), SCROLL_RETRY_TIMEOUT_MS)
+  // unref() prevents the timer from keeping the Node.js/JSDOM event loop alive in tests
+  ;(timeoutId as unknown as { unref?: () => void }).unref?.()
   pendingScrollObservers.set(sectionId, { observer, timeoutId })
-  observer.observe(document.body, { childList: true, subtree: true })
+  observer.observe(root, { childList: true, subtree: true })
 }
 
 /**

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -58,6 +58,13 @@ export function scrollToSection(sectionId: string): void {
   observer.observe(root, { childList: true, subtree: true })
 }
 
+/** @internal For use in tests only — cancels all in-flight scroll observers. */
+export function _clearPendingScrollObservers(): void {
+  for (const sectionId of [...pendingScrollObservers.keys()]) {
+    cancelPendingScroll(sectionId)
+  }
+}
+
 /**
  * Pattern matching dangerous protocols (javascript:, data:, vbscript:, file:, about:).
  */


### PR DESCRIPTION
## Summary

- Lazy-load `Statistics`, `Comparison`, `Testimonials`, `EmailCapture`, `FAQ`, and `CTA` via `React.lazy()` + `Suspense`, keeping `Hero`, `Problem`, `Solution`, `Features`, and `Mobile` eagerly loaded
- Defer `replayIntegration` (Sentry Replay, ~50 KB gzip) to a dynamic import after hydration — core Sentry error tracking remains synchronous
- Update `App.test.tsx` to `await waitFor()` on all lazy-loaded section assertions; `should render without console errors` also flushes lazy loading to prevent act() warnings

## Changes


This PR improves initial load performance by:

1. Converting 6 below-the-fold sections (Statistics, Comparison, Testimonials, EmailCapture, FAQ, CTA) from eager imports to React.lazy() with <Suspense> + <ErrorBoundary fallback={null}>.
2. Making scrollToSection resilient to lazy chunks by using a MutationObserver to wait up to 5s for a section to appear in the DOM.
3. Deferring Sentry replayIntegration to idle time via requestIdleCallback.
4. Fixing ErrorBoundary to accept fallback={null} (falsy but intentional).
5. Updating all affected tests to be async with waitFor.

## Build results

- **Main JS entry chunk**: 119.72 kB gzipped (budget: 150 kB ✅)
- **6 new lazy chunks** produced for below-the-fold sections
- **1408 tests** — all passing ✅

Closes #816

---
