### PR TITLE
fix(ci): replace Maven build step with npm in dependency-check workflow

### DIFF
--- a/.github/workflows/dependancy-check.yml
+++ b/.github/workflows/dependancy-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main@2025-12-10
+        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600 # v1.1.0
         id: Depcheck
         with:
           project: 'test'

--- a/.github/workflows/dependancy-check.yml
+++ b/.github/workflows/dependancy-check.yml
@@ -7,8 +7,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Build project with Maven
-        run: mvn clean install
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - name: Build project with npm
+        run: npm ci && npm run build
       - name: Depcheck
         uses: dependency-check/Dependency-Check_Action@main
         id: Depcheck

--- a/.github/workflows/dependancy-check.yml
+++ b/.github/workflows/dependancy-check.yml
@@ -28,8 +28,8 @@ jobs:
             --failOnCVSS 7
             --enableRetired
       - name: Upload Depcheck report
-        if: always()
+        if: steps.Depcheck.conclusion == 'success' || steps.Depcheck.conclusion == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-           name: Depcheck report
+           name: depcheck-report
            path: ${{github.workspace}}/reports

--- a/.github/workflows/dependancy-check.yml
+++ b/.github/workflows/dependancy-check.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   depchecktest:
     runs-on: ubuntu-latest
-    name: depecheck_test
+    name: depcheck_test
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -12,10 +12,12 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-      - name: Build project with npm
-        run: npm ci && npm run build
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main@2025-12-10
         id: Depcheck
         with:
           project: 'test'
@@ -25,7 +27,8 @@ jobs:
           args: >
             --failOnCVSS 7
             --enableRetired
-      - name: Upload Test results
+      - name: Upload Depcheck report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
            name: Depcheck report

--- a/.github/workflows/dependancy-check.yml
+++ b/.github/workflows/dependancy-check.yml
@@ -6,16 +6,16 @@ jobs:
     name: depecheck_test
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: "npm"
       - name: Build project with npm
         run: npm ci && npm run build
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main
         id: Depcheck
         with:
           project: 'test'
@@ -26,7 +26,7 @@ jobs:
             --failOnCVSS 7
             --enableRetired
       - name: Upload Test results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
            name: Depcheck report
            path: ${{github.workspace}}/reports


### PR DESCRIPTION
## Summary

- The `dependancy-check.yml` workflow was running `mvn clean install` but this is a JavaScript/TypeScript/Vite project with no `pom.xml`
- Replaced the Maven build step with Node.js setup + `npm ci && npm run build`
- The OWASP Dependency-Check action now runs against the correct npm-built output

## Test plan

- [x] Verify the `depecheck_test` job no longer fails with `MissingProjectException`
- [x] Confirm the dependency-check report is still generated and uploaded as an artifact

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNi4imWkkLFfybMTgiC2NG)_